### PR TITLE
Add Argo hybrid daily context pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ Thumbs.db
 # Build products
 build/
 DerivedData/
+.worktrees/
 
 # Swift Package Manager
 .build/

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+struct ArgoDailyContext {
+    let date: Date
+    let dailyEntry: DailyEntry?
+    let events: [ArgoDailyEvent]
+    let nutrition: DailyNutritionSummary?
+    let journalEntries: [JournalEntry]
+    let workoutReflections: [WorkoutReflection]
+    let plannedWorkouts: [TrainingPlan]
+    let healthKitWorkouts: [HKWorkoutSummary]
+    let whoop: WhoopDailyData?
+    let derived: ArgoDailySignals
+
+    static func empty(date: Date, sourceFailures: Set<MissingContextFlag> = []) -> ArgoDailyContext {
+        ArgoDailyContext(
+            date: date,
+            dailyEntry: nil,
+            events: [],
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            derived: ArgoDailySignals(
+                recoveryStatus: .unknown,
+                fuelStatus: .unknown,
+                trainingLoadStatus: .unknown,
+                missingContext: sourceFailures.union([.missingWearableData]),
+                nextAction: nil,
+                summaryText: "No daily context loaded yet."
+            )
+        )
+    }
+}
+
+struct ArgoDailyEvent: Identifiable {
+    let id: String
+    let source: ArgoDailyEventSource
+    let type: ArgoDailyEventType
+    let timestamp: Date?
+    let title: String
+    let summary: String
+    let payload: [String: AnyCodable]
+    let confidence: Double?
+    let requiresReview: Bool
+    let sourceRecordId: String?
+    let isUpcoming: Bool
+
+    static func sortedRecentFirst(_ events: [ArgoDailyEvent]) -> [ArgoDailyEvent] {
+        events.sorted { lhs, rhs in
+            if lhs.isUpcoming != rhs.isUpcoming {
+                return !lhs.isUpcoming && rhs.isUpcoming
+            }
+
+            switch (lhs.timestamp, rhs.timestamp) {
+            case let (left?, right?):
+                return left > right
+            case (.some, .none):
+                return true
+            case (.none, .some):
+                return false
+            case (.none, .none):
+                return lhs.title < rhs.title
+            }
+        }
+    }
+}
+
+enum ArgoDailyEventSource: String, Codable, Sendable {
+    case meal
+    case journal
+    case workoutReflection
+    case trainingPlan
+    case healthKit
+    case whoop
+    case coach
+    case manual
+}
+
+enum ArgoDailyEventType: String, Codable, Sendable {
+    case mealLogged
+    case noteLogged
+    case checkInLogged
+    case workoutPlanned
+    case workoutCompleted
+    case workoutReflected
+    case wearableRecovery
+    case wearableSleep
+    case wearableStrain
+    case coachRecommendation
+}
+
+struct ArgoDailySignals: Sendable {
+    let recoveryStatus: RecoveryStatus
+    let fuelStatus: FuelStatus
+    let trainingLoadStatus: TrainingLoadStatus
+    let missingContext: Set<MissingContextFlag>
+    let nextAction: ArgoCoachAction?
+    let summaryText: String
+}
+
+enum RecoveryStatus: String, Sendable {
+    case unknown
+    case low
+    case moderate
+    case ready
+}
+
+enum FuelStatus: String, Sendable {
+    case unknown
+    case notStarted
+    case underFueled
+    case onTrack
+}
+
+enum TrainingLoadStatus: String, Sendable {
+    case unknown
+    case open
+    case planned
+    case completed
+    case high
+}
+
+enum MissingContextFlag: String, Hashable, Sendable {
+    case noMeals
+    case noPlan
+    case noMorningCheckIn
+    case missingWorkoutReflection
+    case missingWearableData
+    case missingNutritionData
+    case missingJournalData
+    case missingReflectionData
+}
+
+struct ArgoCoachAction: Identifiable, Sendable {
+    let id: String
+    let title: String
+    let body: String
+    let primaryLabel: String
+    let kind: Kind
+
+    enum Kind: String, Sendable {
+        case logMeal
+        case planWorkout
+        case reflectWorkout
+        case adjustTraining
+        case recoveryHabit
+    }
+}
+
+extension Notification.Name {
+    static let argoDailyContextDidChange = Notification.Name("argoDailyContextDidChange")
+}

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift
@@ -50,10 +50,6 @@ struct ArgoDailyEvent: Identifiable {
 
     static func sortedRecentFirst(_ events: [ArgoDailyEvent]) -> [ArgoDailyEvent] {
         events.sorted { lhs, rhs in
-            if lhs.isUpcoming != rhs.isUpcoming {
-                return !lhs.isUpcoming && rhs.isUpcoming
-            }
-
             switch (lhs.timestamp, rhs.timestamp) {
             case let (left?, right?):
                 return left > right
@@ -130,6 +126,8 @@ enum MissingContextFlag: String, Hashable, Sendable {
     case missingWorkoutReflection
     case missingWearableData
     case missingNutritionData
+    case missingDailyEntryData
+    case missingTrainingPlanData
     case missingJournalData
     case missingReflectionData
 }
@@ -146,6 +144,7 @@ struct ArgoCoachAction: Identifiable, Sendable {
         case planWorkout
         case reflectWorkout
         case adjustTraining
+        case checkIn
         case recoveryHabit
     }
 }

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+enum ArgoDailyEventMapper {
+    static func makeEvents(
+        dailyEntry: DailyEntry?,
+        nutrition: DailyNutritionSummary?,
+        journalEntries: [JournalEntry],
+        workoutReflections: [WorkoutReflection],
+        plannedWorkouts: [TrainingPlan],
+        healthKitWorkouts: [HKWorkoutSummary],
+        whoop: WhoopDailyData?,
+        now: Date = Date()
+    ) -> [ArgoDailyEvent] {
+        var events: [ArgoDailyEvent] = []
+        events.append(contentsOf: nutrition?.meals.map(makeMealEvent) ?? [])
+        events.append(contentsOf: journalEntries.map(makeJournalEvent))
+        events.append(contentsOf: workoutReflections.map(makeWorkoutReflectionEvent))
+        events.append(contentsOf: plannedWorkouts.map { makeTrainingPlanEvent($0, now: now) })
+        events.append(contentsOf: healthKitWorkouts.map(makeHealthKitWorkoutEvent))
+        events.append(contentsOf: makeWhoopEvents(whoop))
+
+        if let completedAt = dailyEntry?.morningCompletedAt {
+            events.append(makeCheckInEvent(id: "morning-check-in", title: "Morning check-in", timestamp: completedAt))
+        }
+
+        if let completedAt = dailyEntry?.eveningCompletedAt {
+            events.append(makeCheckInEvent(id: "evening-check-in", title: "Evening reflection", timestamp: completedAt))
+        }
+
+        return ArgoDailyEvent.sortedRecentFirst(events)
+    }
+
+    static func makeMealEvent(_ meal: Meal) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: "meal-\(meal.id.uuidString)",
+            source: .meal,
+            type: .mealLogged,
+            timestamp: meal.createdAt ?? meal.date,
+            title: "\(meal.mealTypeDisplayName) logged",
+            summary: "\(meal.calories) cal - \(Int(meal.proteinG))g protein",
+            payload: [
+                "meal_type": AnyCodable(meal.mealType),
+                "calories": AnyCodable(meal.calories),
+                "protein_g": AnyCodable(meal.proteinG)
+            ],
+            confidence: meal.aiConfidence,
+            requiresReview: (meal.aiConfidence ?? 1.0) < 0.65,
+            sourceRecordId: meal.id.uuidString,
+            isUpcoming: false
+        )
+    }
+
+    static func makeJournalEvent(_ entry: JournalEntry) -> ArgoDailyEvent {
+        let isCheckIn = entry.tags?.contains("check-in") == true
+
+        return ArgoDailyEvent(
+            id: "journal-\(entry.id.uuidString)",
+            source: .journal,
+            type: isCheckIn ? .checkInLogged : .noteLogged,
+            timestamp: entry.createdAt,
+            title: entry.displayTitle,
+            summary: entry.contentPreview,
+            payload: [
+                "mood": AnyCodable(entry.mood ?? 0),
+                "energy": AnyCodable(entry.energy ?? 0)
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: entry.id.uuidString,
+            isUpcoming: false
+        )
+    }
+
+    static func makeWorkoutReflectionEvent(_ reflection: WorkoutReflection) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: "reflection-\(reflection.id.uuidString)",
+            source: .workoutReflection,
+            type: .workoutReflected,
+            timestamp: reflection.createdAt ?? reflection.date,
+            title: "\(reflection.activityType.displayName) reflected",
+            summary: reflection.formattedDuration ?? "Workout reflection saved",
+            payload: [
+                "training_feeling": AnyCodable(reflection.trainingFeeling ?? 0),
+                "energy_level": AnyCodable(reflection.energyLevel ?? 0)
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: reflection.id.uuidString,
+            isUpcoming: false
+        )
+    }
+
+    static func makeTrainingPlanEvent(_ plan: TrainingPlan, now: Date = Date()) -> ArgoDailyEvent {
+        let eventDate = dateForPlan(plan)
+        let upcoming = eventDate.map { $0 > now } ?? true
+        let summary = [plan.formattedDuration, plan.intensityLevel.displayName]
+            .compactMap { $0 }
+            .joined(separator: " - ")
+
+        return ArgoDailyEvent(
+            id: "plan-\(plan.id.uuidString)",
+            source: .trainingPlan,
+            type: .workoutPlanned,
+            timestamp: eventDate,
+            title: upcoming ? "Upcoming \(plan.activityType.displayName)" : plan.activityType.displayName,
+            summary: summary.isEmpty ? "Planned workout" : summary,
+            payload: [
+                "training_type": AnyCodable(plan.trainingType ?? ""),
+                "intensity": AnyCodable(plan.intensity ?? "")
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: plan.id.uuidString,
+            isUpcoming: upcoming
+        )
+    }
+
+    static func makeHealthKitWorkoutEvent(_ workout: HKWorkoutSummary) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: "healthkit-\(workout.id)",
+            source: .healthKit,
+            type: .workoutCompleted,
+            timestamp: workout.endDate,
+            title: "\(workout.activityName) completed",
+            summary: "\(workout.durationMinutes) min - \(workout.totalCalories) cal",
+            payload: [
+                "duration_minutes": AnyCodable(workout.durationMinutes),
+                "calories": AnyCodable(workout.totalCalories)
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: workout.id,
+            isUpcoming: false
+        )
+    }
+
+    static func makeWhoopEvents(_ whoop: WhoopDailyData?) -> [ArgoDailyEvent] {
+        guard let whoop else { return [] }
+
+        let timestamp = whoop.fetchedAt ?? whoop.date
+        let sourceRecordId = whoop.id?.uuidString
+        var events: [ArgoDailyEvent] = []
+
+        if let recovery = whoop.recoveryScore {
+            events.append(ArgoDailyEvent(
+                id: "whoop-recovery",
+                source: .whoop,
+                type: .wearableRecovery,
+                timestamp: timestamp,
+                title: "Recovery updated",
+                summary: "\(Int(recovery.rounded()))% recovery",
+                payload: [
+                    "recovery_score": AnyCodable(recovery),
+                    "recovery_zone": AnyCodable(whoop.recoveryZone?.rawValue ?? "")
+                ],
+                confidence: nil,
+                requiresReview: false,
+                sourceRecordId: sourceRecordId,
+                isUpcoming: false
+            ))
+        }
+
+        if let sleepPerformance = whoop.sleepPerformance {
+            events.append(ArgoDailyEvent(
+                id: "whoop-sleep",
+                source: .whoop,
+                type: .wearableSleep,
+                timestamp: timestamp,
+                title: "Sleep updated",
+                summary: "\(Int(sleepPerformance.rounded()))% sleep performance",
+                payload: [
+                    "sleep_performance": AnyCodable(sleepPerformance),
+                    "sleep_duration_minutes": AnyCodable(whoop.sleepDurationMinutes ?? 0)
+                ],
+                confidence: nil,
+                requiresReview: false,
+                sourceRecordId: sourceRecordId,
+                isUpcoming: false
+            ))
+        }
+
+        if let strain = whoop.strainScore {
+            events.append(ArgoDailyEvent(
+                id: "whoop-strain",
+                source: .whoop,
+                type: .wearableStrain,
+                timestamp: timestamp,
+                title: "Strain updated",
+                summary: String(format: "%.1f strain", strain),
+                payload: ["strain_score": AnyCodable(strain)],
+                confidence: nil,
+                requiresReview: false,
+                sourceRecordId: sourceRecordId,
+                isUpcoming: false
+            ))
+        }
+
+        return events
+    }
+
+    static func makeCheckInEvent(id: String, title: String, timestamp: Date) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: id,
+            source: .manual,
+            type: .checkInLogged,
+            timestamp: timestamp,
+            title: title,
+            summary: "Completed",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: nil,
+            isUpcoming: false
+        )
+    }
+
+    private static func dateForPlan(_ plan: TrainingPlan) -> Date? {
+        guard let startTime = plan.startTime else { return plan.date }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let combined = "\(dateFormatter.string(from: plan.date)) \(startTime)"
+        let combinedFormatter = DateFormatter()
+        combinedFormatter.dateFormat = startTime.count == 5 ? "yyyy-MM-dd HH:mm" : "yyyy-MM-dd HH:mm:ss"
+
+        return combinedFormatter.date(from: combined) ?? plan.date
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift
@@ -215,7 +215,7 @@ enum ArgoDailyEventMapper {
     }
 
     private static func dateForPlan(_ plan: TrainingPlan) -> Date? {
-        guard let startTime = plan.startTime else { return plan.date }
+        guard let startTime = plan.startTime else { return nil }
 
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
@@ -224,6 +224,6 @@ enum ArgoDailyEventMapper {
         let combinedFormatter = DateFormatter()
         combinedFormatter.dateFormat = startTime.count == 5 ? "yyyy-MM-dd HH:mm" : "yyyy-MM-dd HH:mm:ss"
 
-        return combinedFormatter.date(from: combined) ?? plan.date
+        return combinedFormatter.date(from: combined)
     }
 }

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailySignalsEvaluator.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailySignalsEvaluator.swift
@@ -1,0 +1,281 @@
+import Foundation
+
+enum ArgoDailySignalsEvaluator {
+    public static func evaluate(
+        date: Date,
+        dailyEntry: DailyEntry?,
+        nutrition: DailyNutritionSummary?,
+        journalEntries: [JournalEntry],
+        workoutReflections: [WorkoutReflection],
+        plannedWorkouts: [TrainingPlan],
+        healthKitWorkouts: [HKWorkoutSummary],
+        whoop: WhoopDailyData?,
+        sourceFailures: Set<MissingContextFlag>
+    ) -> ArgoDailySignals {
+        let recoveryStatus = recoveryStatus(from: whoop)
+        let fuelStatus = fuelStatus(from: nutrition)
+        let trainingLoadStatus = trainingLoadStatus(
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            workoutReflections: workoutReflections,
+            whoop: whoop
+        )
+        let missingContext = missingContext(
+            dailyEntry: dailyEntry,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop,
+            sourceFailures: sourceFailures
+        )
+        let action = nextAction(
+            recoveryStatus: recoveryStatus,
+            trainingLoadStatus: trainingLoadStatus,
+            missingContext: missingContext
+        )
+
+        return ArgoDailySignals(
+            recoveryStatus: recoveryStatus,
+            fuelStatus: fuelStatus,
+            trainingLoadStatus: trainingLoadStatus,
+            missingContext: missingContext,
+            nextAction: action,
+            summaryText: summaryText(
+                date: date,
+                recoveryStatus: recoveryStatus,
+                fuelStatus: fuelStatus,
+                trainingLoadStatus: trainingLoadStatus,
+                missingContext: missingContext
+            )
+        )
+    }
+
+    private static func recoveryStatus(from whoop: WhoopDailyData?) -> RecoveryStatus {
+        guard let whoop else {
+            return .unknown
+        }
+
+        if whoop.recoveryZone == .red {
+            return .low
+        }
+
+        if whoop.recoveryZone == .green {
+            return .ready
+        }
+
+        if let score = whoop.recoveryScore {
+            if score < 34 {
+                return .low
+            }
+            if score >= 67 {
+                return .ready
+            }
+        }
+
+        return .moderate
+    }
+
+    private static func fuelStatus(from nutrition: DailyNutritionSummary?) -> FuelStatus {
+        guard let nutrition else {
+            return .notStarted
+        }
+
+        if nutrition.mealCount == 0 && nutrition.meals.isEmpty {
+            return .notStarted
+        }
+
+        if nutrition.totalCalories < 1_200 || nutrition.totalProteinG < 50 {
+            return .underFueled
+        }
+
+        return .onTrack
+    }
+
+    private static func trainingLoadStatus(
+        plannedWorkouts: [TrainingPlan],
+        healthKitWorkouts: [HKWorkoutSummary],
+        workoutReflections: [WorkoutReflection],
+        whoop: WhoopDailyData?
+    ) -> TrainingLoadStatus {
+        if let strainScore = whoop?.strainScore, strainScore >= 14 {
+            return .high
+        }
+
+        if !healthKitWorkouts.isEmpty || !workoutReflections.isEmpty {
+            let healthKitWorkoutIds = Set(healthKitWorkouts.map(\.id))
+            let unlinkedReflections = workoutReflections.filter { reflection in
+                guard let appleWorkoutId = reflection.appleWorkoutId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !appleWorkoutId.isEmpty else {
+                    return true
+                }
+
+                return !healthKitWorkoutIds.contains(appleWorkoutId)
+            }
+            let completedMinutes = healthKitWorkouts.reduce(0) { $0 + $1.durationMinutes }
+                + unlinkedReflections.reduce(0) { $0 + ($1.durationMinutes ?? 0) }
+            let workoutCount = healthKitWorkouts.count + unlinkedReflections.count
+
+            if completedMinutes >= 90 || workoutCount > 1 {
+                return .high
+            }
+
+            return .completed
+        }
+
+        if !plannedWorkouts.isEmpty {
+            return .planned
+        }
+
+        return .open
+    }
+
+    private static func missingContext(
+        dailyEntry: DailyEntry?,
+        nutrition: DailyNutritionSummary?,
+        journalEntries: [JournalEntry],
+        workoutReflections: [WorkoutReflection],
+        plannedWorkouts: [TrainingPlan],
+        healthKitWorkouts: [HKWorkoutSummary],
+        whoop: WhoopDailyData?,
+        sourceFailures: Set<MissingContextFlag>
+    ) -> Set<MissingContextFlag> {
+        var flags = sourceFailures
+
+        if nutrition == nil || (nutrition?.mealCount == 0 && nutrition?.meals.isEmpty == true) {
+            flags.insert(.noMeals)
+        }
+
+        if plannedWorkouts.isEmpty && !hasLegacyTrainingPlan(dailyEntry) {
+            flags.insert(.noPlan)
+        }
+
+        if dailyEntry?.isMorningComplete != true {
+            flags.insert(.noMorningCheckIn)
+        }
+
+        if hasHealthKitWorkoutMissingReflection(
+            healthKitWorkouts: healthKitWorkouts,
+            workoutReflections: workoutReflections
+        ) {
+            flags.insert(.missingWorkoutReflection)
+        }
+
+        if whoop == nil {
+            flags.insert(.missingWearableData)
+        }
+
+        return flags
+    }
+
+    private static func hasHealthKitWorkoutMissingReflection(
+        healthKitWorkouts: [HKWorkoutSummary],
+        workoutReflections: [WorkoutReflection]
+    ) -> Bool {
+        let linkedAppleWorkoutIds = appleWorkoutIds(from: workoutReflections)
+        return healthKitWorkouts.contains { !linkedAppleWorkoutIds.contains($0.id) }
+    }
+
+    private static func appleWorkoutIds(from workoutReflections: [WorkoutReflection]) -> Set<String> {
+        Set(workoutReflections.compactMap { reflection in
+            guard let appleWorkoutId = reflection.appleWorkoutId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !appleWorkoutId.isEmpty else {
+                return nil
+            }
+
+            return appleWorkoutId
+        })
+    }
+
+    private static func hasLegacyTrainingPlan(_ dailyEntry: DailyEntry?) -> Bool {
+        guard let dailyEntry else {
+            return false
+        }
+
+        return isNonEmpty(dailyEntry.plannedTrainingType)
+            || isNonEmpty(dailyEntry.plannedTrainingTime)
+            || isNonEmpty(dailyEntry.plannedIntensity)
+            || (dailyEntry.plannedDuration ?? 0) > 0
+    }
+
+    private static func isNonEmpty(_ value: String?) -> Bool {
+        guard let value else {
+            return false
+        }
+
+        return !value.isEmpty
+    }
+
+    private static func nextAction(
+        recoveryStatus: RecoveryStatus,
+        trainingLoadStatus: TrainingLoadStatus,
+        missingContext: Set<MissingContextFlag>
+    ) -> ArgoCoachAction? {
+        if missingContext.contains(.missingWorkoutReflection) {
+            return ArgoCoachAction(
+                id: "reflect-workout",
+                title: "Reflect on the workout.",
+                body: "Log how the completed session felt so Argo can connect training load with readiness.",
+                primaryLabel: "Add reflection",
+                kind: .reflectWorkout
+            )
+        }
+
+        if recoveryStatus == .low && (trainingLoadStatus == .planned || trainingLoadStatus == .high) {
+            return ArgoCoachAction(
+                id: "adjust-training",
+                title: "Adjust today's training.",
+                body: "Recovery is low while training load is scheduled or elevated. Keep the session lighter.",
+                primaryLabel: "Review plan",
+                kind: .adjustTraining
+            )
+        }
+
+        if missingContext.contains(.noMeals) {
+            return ArgoCoachAction(
+                id: "log-meal",
+                title: "Log your first meal.",
+                body: "Add a meal so Argo can evaluate fuel against today's training demand.",
+                primaryLabel: "Log meal",
+                kind: .logMeal
+            )
+        }
+
+        if missingContext.contains(.noPlan) {
+            return ArgoCoachAction(
+                id: "plan-workout",
+                title: "Set today's training plan.",
+                body: "Add a plan or mark today open so Argo can reason about load.",
+                primaryLabel: "Plan workout",
+                kind: .planWorkout
+            )
+        }
+
+        return ArgoCoachAction(
+            id: "recovery-habit",
+            title: "Anchor recovery today.",
+            body: "Keep hydration, sleep timing, and mobility consistent to support tomorrow's readiness.",
+            primaryLabel: "Start habit",
+            kind: .recoveryHabit
+        )
+    }
+
+    private static func summaryText(
+        date: Date,
+        recoveryStatus: RecoveryStatus,
+        fuelStatus: FuelStatus,
+        trainingLoadStatus: TrainingLoadStatus,
+        missingContext: Set<MissingContextFlag>
+    ) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+
+        if !missingContext.isEmpty {
+            return "\(formatter.string(from: date)): \(missingContext.count) context gaps need attention."
+        }
+
+        return "\(formatter.string(from: date)): recovery is \(recoveryStatus.rawValue), fuel is \(fuelStatus.rawValue), and training load is \(trainingLoadStatus.rawValue)."
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailySignalsEvaluator.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailySignalsEvaluator.swift
@@ -104,20 +104,12 @@ enum ArgoDailySignalsEvaluator {
         }
 
         if !healthKitWorkouts.isEmpty || !workoutReflections.isEmpty {
-            let healthKitWorkoutIds = Set(healthKitWorkouts.map(\.id))
-            let unlinkedReflections = workoutReflections.filter { reflection in
-                guard let appleWorkoutId = reflection.appleWorkoutId?.trimmingCharacters(in: .whitespacesAndNewlines),
-                      !appleWorkoutId.isEmpty else {
-                    return true
-                }
+            let totals = completedWorkoutTotals(
+                healthKitWorkouts: healthKitWorkouts,
+                workoutReflections: workoutReflections
+            )
 
-                return !healthKitWorkoutIds.contains(appleWorkoutId)
-            }
-            let completedMinutes = healthKitWorkouts.reduce(0) { $0 + $1.durationMinutes }
-                + unlinkedReflections.reduce(0) { $0 + ($1.durationMinutes ?? 0) }
-            let workoutCount = healthKitWorkouts.count + unlinkedReflections.count
-
-            if completedMinutes >= 90 || workoutCount > 1 {
+            if totals.minutes >= 90 || totals.count > 1 {
                 return .high
             }
 
@@ -147,11 +139,13 @@ enum ArgoDailySignalsEvaluator {
             flags.insert(.noMeals)
         }
 
-        if plannedWorkouts.isEmpty && !hasLegacyTrainingPlan(dailyEntry) {
+        if plannedWorkouts.isEmpty
+            && !hasLegacyTrainingPlan(dailyEntry)
+            && !sourceFailures.contains(.missingTrainingPlanData) {
             flags.insert(.noPlan)
         }
 
-        if dailyEntry?.isMorningComplete != true {
+        if dailyEntry?.isMorningComplete != true && !sourceFailures.contains(.missingDailyEntryData) {
             flags.insert(.noMorningCheckIn)
         }
 
@@ -175,6 +169,33 @@ enum ArgoDailySignalsEvaluator {
     ) -> Bool {
         let linkedAppleWorkoutIds = appleWorkoutIds(from: workoutReflections)
         return healthKitWorkouts.contains { !linkedAppleWorkoutIds.contains($0.id) }
+    }
+
+    private static func completedWorkoutTotals(
+        healthKitWorkouts: [HKWorkoutSummary],
+        workoutReflections: [WorkoutReflection]
+    ) -> (minutes: Int, count: Int) {
+        guard !healthKitWorkouts.isEmpty else {
+            return (
+                workoutReflections.reduce(0) { $0 + ($1.durationMinutes ?? 0) },
+                workoutReflections.count
+            )
+        }
+
+        let healthKitWorkoutIds = Set(healthKitWorkouts.map(\.id))
+        let unlinkedReflections = workoutReflections.filter { reflection in
+            guard let appleWorkoutId = reflection.appleWorkoutId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !appleWorkoutId.isEmpty else {
+                return true
+            }
+
+            return !healthKitWorkoutIds.contains(appleWorkoutId)
+        }
+        let minutes = healthKitWorkouts.reduce(0) { $0 + $1.durationMinutes }
+            + unlinkedReflections.reduce(0) { $0 + ($1.durationMinutes ?? 0) }
+        let count = healthKitWorkouts.count + unlinkedReflections.count
+
+        return (minutes, count)
     }
 
     private static func appleWorkoutIds(from workoutReflections: [WorkoutReflection]) -> Set<String> {
@@ -249,6 +270,16 @@ enum ArgoDailySignalsEvaluator {
                 body: "Add a plan or mark today open so Argo can reason about load.",
                 primaryLabel: "Plan workout",
                 kind: .planWorkout
+            )
+        }
+
+        if missingContext.contains(.noMorningCheckIn) {
+            return ArgoCoachAction(
+                id: "morning-check-in",
+                title: "Add a quick check-in.",
+                body: "Capture how you feel this morning so Argo can adjust training, fuel, and recovery advice.",
+                primaryLabel: "Check in",
+                kind: .checkIn
             )
         }
 

--- a/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+protocol DailyContextProviding: AnyObject {
+    @MainActor func context(for date: Date) async -> ArgoDailyContext
+    @MainActor func refresh(for date: Date) async -> ArgoDailyContext
+}
+
+@MainActor
+final class ClientDailyContextService: DailyContextProviding {
+    private let mealsService: MealsServiceProtocol
+    private let journalService: JournalEntriesServiceProtocol
+    private let workoutReflectionsService: WorkoutReflectionsServiceProtocol
+    private let dailyEntriesService: DailyEntriesServiceProtocol
+    private let whoopDataProvider: () -> WhoopDailyData?
+    private let healthKitWorkoutsProvider: () -> [HKWorkoutSummary]
+
+    init(
+        mealsService: MealsServiceProtocol = MealsService(),
+        journalService: JournalEntriesServiceProtocol = JournalEntriesService(),
+        workoutReflectionsService: WorkoutReflectionsServiceProtocol = WorkoutReflectionsService(),
+        dailyEntriesService: DailyEntriesServiceProtocol = DailyEntriesService(),
+        whoopDataProvider: @escaping () -> WhoopDailyData? = { WhoopService.shared.dailyData },
+        healthKitWorkoutsProvider: @escaping () -> [HKWorkoutSummary] = { HealthKitService.shared.todayWorkouts }
+    ) {
+        self.mealsService = mealsService
+        self.journalService = journalService
+        self.workoutReflectionsService = workoutReflectionsService
+        self.dailyEntriesService = dailyEntriesService
+        self.whoopDataProvider = whoopDataProvider
+        self.healthKitWorkoutsProvider = healthKitWorkoutsProvider
+    }
+
+    func context(for date: Date) async -> ArgoDailyContext {
+        await refresh(for: date)
+    }
+
+    func refresh(for date: Date) async -> ArgoDailyContext {
+        var sourceFailures: Set<MissingContextFlag> = []
+
+        let dailyEntry: DailyEntry?
+        do {
+            dailyEntry = try await dailyEntriesService.getEntry(for: date)
+        } catch {
+            dailyEntry = nil
+        }
+
+        let plannedWorkouts: [TrainingPlan]
+        do {
+            plannedWorkouts = try await dailyEntriesService.getTrainingPlans(for: date)
+        } catch {
+            plannedWorkouts = []
+        }
+
+        let nutrition: DailyNutritionSummary?
+        do {
+            nutrition = try await mealsService.getDailyNutrition(date: dateString(date))
+        } catch {
+            nutrition = nil
+            sourceFailures.insert(.missingNutritionData)
+        }
+
+        let journalEntries: [JournalEntry]
+        do {
+            journalEntries = try await journalService.fetchEntriesForDate(date)
+        } catch {
+            journalEntries = []
+            sourceFailures.insert(.missingJournalData)
+        }
+
+        let workoutReflections: [WorkoutReflection]
+        do {
+            workoutReflections = try await workoutReflectionsService.list(date: date)
+        } catch {
+            workoutReflections = []
+            sourceFailures.insert(.missingReflectionData)
+        }
+
+        let whoop = whoopDataProvider()
+        let healthKitWorkouts = healthKitWorkoutsProvider()
+        let derived = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: dailyEntry,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop,
+            sourceFailures: sourceFailures
+        )
+        let events = ArgoDailyEventMapper.makeEvents(
+            dailyEntry: dailyEntry,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop
+        )
+
+        return ArgoDailyContext(
+            date: date,
+            dailyEntry: dailyEntry,
+            events: events,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop,
+            derived: derived
+        )
+    }
+
+    private func dateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
@@ -11,16 +11,22 @@ final class ClientDailyContextService: DailyContextProviding {
     private let journalService: JournalEntriesServiceProtocol
     private let workoutReflectionsService: WorkoutReflectionsServiceProtocol
     private let dailyEntriesService: DailyEntriesServiceProtocol
-    private let whoopDataProvider: () -> WhoopDailyData?
-    private let healthKitWorkoutsProvider: () -> [HKWorkoutSummary]
+    private let whoopDataProvider: (Date) -> WhoopDailyData?
+    private let healthKitWorkoutsProvider: (Date) -> [HKWorkoutSummary]
 
     init(
         mealsService: MealsServiceProtocol = MealsService(),
         journalService: JournalEntriesServiceProtocol = JournalEntriesService(),
         workoutReflectionsService: WorkoutReflectionsServiceProtocol = WorkoutReflectionsService(),
         dailyEntriesService: DailyEntriesServiceProtocol = DailyEntriesService(),
-        whoopDataProvider: @escaping () -> WhoopDailyData? = { WhoopService.shared.dailyData },
-        healthKitWorkoutsProvider: @escaping () -> [HKWorkoutSummary] = { HealthKitService.shared.todayWorkouts }
+        whoopDataProvider: @escaping (Date) -> WhoopDailyData? = { date in
+            guard Calendar.current.isDateInToday(date) else { return nil }
+            return WhoopService.shared.dailyData
+        },
+        healthKitWorkoutsProvider: @escaping (Date) -> [HKWorkoutSummary] = { date in
+            guard Calendar.current.isDateInToday(date) else { return [] }
+            return HealthKitService.shared.todayWorkouts
+        }
     ) {
         self.mealsService = mealsService
         self.journalService = journalService
@@ -75,8 +81,8 @@ final class ClientDailyContextService: DailyContextProviding {
             sourceFailures.insert(.missingReflectionData)
         }
 
-        let whoop = whoopDataProvider()
-        let healthKitWorkouts = healthKitWorkoutsProvider()
+        let whoop = whoopDataProvider(date)
+        let healthKitWorkouts = healthKitWorkoutsProvider(date)
         let derived = ArgoDailySignalsEvaluator.evaluate(
             date: date,
             dailyEntry: dailyEntry,

--- a/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
@@ -11,29 +11,29 @@ final class ClientDailyContextService: DailyContextProviding {
     private let journalService: JournalEntriesServiceProtocol
     private let workoutReflectionsService: WorkoutReflectionsServiceProtocol
     private let dailyEntriesService: DailyEntriesServiceProtocol
-    private let whoopDataProvider: (Date) -> WhoopDailyData?
-    private let healthKitWorkoutsProvider: (Date) -> [HKWorkoutSummary]
+    private let whoopDataProvider: @MainActor (Date) -> WhoopDailyData?
+    private let healthKitWorkoutsProvider: @MainActor (Date) -> [HKWorkoutSummary]
 
     init(
-        mealsService: MealsServiceProtocol = MealsService(),
-        journalService: JournalEntriesServiceProtocol = JournalEntriesService(),
-        workoutReflectionsService: WorkoutReflectionsServiceProtocol = WorkoutReflectionsService(),
-        dailyEntriesService: DailyEntriesServiceProtocol = DailyEntriesService(),
-        whoopDataProvider: @escaping (Date) -> WhoopDailyData? = { date in
+        mealsService: MealsServiceProtocol? = nil,
+        journalService: JournalEntriesServiceProtocol? = nil,
+        workoutReflectionsService: WorkoutReflectionsServiceProtocol? = nil,
+        dailyEntriesService: DailyEntriesServiceProtocol? = nil,
+        whoopDataProvider: (@MainActor (Date) -> WhoopDailyData?)? = nil,
+        healthKitWorkoutsProvider: (@MainActor (Date) -> [HKWorkoutSummary])? = nil
+    ) {
+        self.mealsService = mealsService ?? MealsService()
+        self.journalService = journalService ?? JournalEntriesService()
+        self.workoutReflectionsService = workoutReflectionsService ?? WorkoutReflectionsService()
+        self.dailyEntriesService = dailyEntriesService ?? DailyEntriesService()
+        self.whoopDataProvider = whoopDataProvider ?? { date in
             guard Calendar.current.isDateInToday(date) else { return nil }
             return WhoopService.shared.dailyData
-        },
-        healthKitWorkoutsProvider: @escaping (Date) -> [HKWorkoutSummary] = { date in
+        }
+        self.healthKitWorkoutsProvider = healthKitWorkoutsProvider ?? { date in
             guard Calendar.current.isDateInToday(date) else { return [] }
             return HealthKitService.shared.todayWorkouts
         }
-    ) {
-        self.mealsService = mealsService
-        self.journalService = journalService
-        self.workoutReflectionsService = workoutReflectionsService
-        self.dailyEntriesService = dailyEntriesService
-        self.whoopDataProvider = whoopDataProvider
-        self.healthKitWorkoutsProvider = healthKitWorkoutsProvider
     }
 
     func context(for date: Date) async -> ArgoDailyContext {
@@ -48,6 +48,7 @@ final class ClientDailyContextService: DailyContextProviding {
             dailyEntry = try await dailyEntriesService.getEntry(for: date)
         } catch {
             dailyEntry = nil
+            sourceFailures.insert(.missingDailyEntryData)
         }
 
         let plannedWorkouts: [TrainingPlan]
@@ -55,6 +56,7 @@ final class ClientDailyContextService: DailyContextProviding {
             plannedWorkouts = try await dailyEntriesService.getTrainingPlans(for: date)
         } catch {
             plannedWorkouts = []
+            sourceFailures.insert(.missingTrainingPlanData)
         }
 
         let nutrition: DailyNutritionSummary?

--- a/DailyRitualSwiftiOS/Your Daily Dose/Services/WorkoutReflectionsService.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Services/WorkoutReflectionsService.swift
@@ -31,11 +31,8 @@ struct WorkoutReflectionStats: Codable, Sendable {
     }
 }
 
-@MainActor
-struct WorkoutReflectionsService: WorkoutReflectionsServiceProtocol {
-    private var apiClient: APIClient { SupabaseManager.shared.api }
-
-    func create(_ reflection: WorkoutReflection) async throws -> WorkoutReflection {
+enum WorkoutReflectionPayloadBuilder {
+    static func createPayload(from reflection: WorkoutReflection) -> [String: Any] {
         var body: [String: Any] = [:]
         if let feeling = reflection.trainingFeeling { body["training_feeling"] = feeling }
         if let well = reflection.whatWentWell { body["what_went_well"] = well }
@@ -48,7 +45,33 @@ struct WorkoutReflectionsService: WorkoutReflectionsServiceProtocol {
         if let calories = reflection.caloriesBurned { body["calories_burned"] = calories }
         if let avgHr = reflection.averageHr { body["average_hr"] = avgHr }
         if let maxHr = reflection.maxHr { body["max_hr"] = maxHr }
+        if let stravaActivityId = reflection.stravaActivityId, !stravaActivityId.isEmpty { body["strava_activity_id"] = stravaActivityId }
+        if let appleWorkoutId = reflection.appleWorkoutId, !appleWorkoutId.isEmpty { body["apple_workout_id"] = appleWorkoutId }
+        if let whoopActivityId = reflection.whoopActivityId, !whoopActivityId.isEmpty { body["whoop_activity_id"] = whoopActivityId }
+        return body
+    }
 
+    static func updatePayload(from reflection: WorkoutReflection) -> [String: Any] {
+        var body: [String: Any] = [:]
+        if let feeling = reflection.trainingFeeling { body["training_feeling"] = feeling }
+        if let well = reflection.whatWentWell { body["what_went_well"] = well }
+        if let improve = reflection.whatToImprove { body["what_to_improve"] = improve }
+        if let energy = reflection.energyLevel { body["energy_level"] = energy }
+        if let focus = reflection.focusLevel { body["focus_level"] = focus }
+        if let type = reflection.workoutType { body["workout_type"] = type }
+        if let intensity = reflection.workoutIntensity { body["workout_intensity"] = intensity }
+        if let duration = reflection.durationMinutes { body["duration_minutes"] = duration }
+        if let appleWorkoutId = reflection.appleWorkoutId { body["apple_workout_id"] = appleWorkoutId }
+        return body
+    }
+}
+
+@MainActor
+struct WorkoutReflectionsService: WorkoutReflectionsServiceProtocol {
+    private var apiClient: APIClient { SupabaseManager.shared.api }
+
+    func create(_ reflection: WorkoutReflection) async throws -> WorkoutReflection {
+        let body = WorkoutReflectionPayloadBuilder.createPayload(from: reflection)
         let response: APIResponse<WorkoutReflection> = try await apiClient.postRaw("workout-reflections", json: body)
         if let created = response.data {
             return created
@@ -73,16 +96,7 @@ struct WorkoutReflectionsService: WorkoutReflectionsServiceProtocol {
     }
 
     func update(_ reflection: WorkoutReflection) async throws -> WorkoutReflection {
-        var body: [String: Any] = [:]
-        if let feeling = reflection.trainingFeeling { body["training_feeling"] = feeling }
-        if let well = reflection.whatWentWell { body["what_went_well"] = well }
-        if let improve = reflection.whatToImprove { body["what_to_improve"] = improve }
-        if let energy = reflection.energyLevel { body["energy_level"] = energy }
-        if let focus = reflection.focusLevel { body["focus_level"] = focus }
-        if let type = reflection.workoutType { body["workout_type"] = type }
-        if let intensity = reflection.workoutIntensity { body["workout_intensity"] = intensity }
-        if let duration = reflection.durationMinutes { body["duration_minutes"] = duration }
-
+        let body = WorkoutReflectionPayloadBuilder.updatePayload(from: reflection)
         let response: APIResponse<WorkoutReflection> = try await apiClient.putRaw("workout-reflections/\(reflection.id)", json: body)
         return response.data ?? reflection
     }

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
@@ -12,8 +12,9 @@ struct CoachView: View {
     @State private var context: ArgoDailyContext?
     @State private var contextRefreshID = UUID()
 
-    init(contextService: DailyContextProviding = ClientDailyContextService()) {
-        self.contextService = contextService
+    @MainActor
+    init(contextService: DailyContextProviding? = nil) {
+        self.contextService = contextService ?? ClientDailyContextService()
     }
 
     private var recommendations: [ArgoCoachAction] {

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
@@ -8,23 +8,53 @@
 import SwiftUI
 
 struct CoachView: View {
-    private let recommendations = [
-        CoachRecommendation(
-            title: "Keep today's lift moderate.",
-            body: "Recovery is trending lower than your weekly baseline. Cap hard sets and leave one rep in reserve.",
-            action: "Adjust plan"
-        ),
-        CoachRecommendation(
-            title: "Add 35g protein by dinner.",
-            body: "Your meal log is pacing below target. A simple lean protein serving closes most of the gap.",
-            action: "Plan meal"
-        ),
-        CoachRecommendation(
-            title: "Protect a quiet block tonight.",
-            body: "Two late sessions in a row usually push your next-day readiness down. Schedule 30 minutes off screens.",
-            action: "Add habit"
-        )
-    ]
+    private let contextService: DailyContextProviding
+    @State private var context: ArgoDailyContext?
+    @State private var contextRefreshID = UUID()
+
+    init(contextService: DailyContextProviding = ClientDailyContextService()) {
+        self.contextService = contextService
+    }
+
+    private var recommendations: [ArgoCoachAction] {
+        var actions: [ArgoCoachAction] = []
+
+        func appendIfUnique(_ action: ArgoCoachAction) {
+            guard !actions.contains(where: { $0.id == action.id }) else { return }
+            actions.append(action)
+        }
+
+        if let nextAction = context?.derived.nextAction {
+            appendIfUnique(nextAction)
+        }
+
+        if context?.derived.missingContext.contains(.noMeals) == true,
+           !actions.contains(where: { $0.kind == .logMeal }) {
+            appendIfUnique(
+                ArgoCoachAction(
+                    id: "coach-log-meal",
+                    title: "Add food context.",
+                    body: "A quick meal photo or text note helps Argo estimate fuel for the rest of the day.",
+                    primaryLabel: "Log meal",
+                    kind: .logMeal
+                )
+            )
+        }
+
+        if context?.derived.missingContext.contains(.missingWearableData) == true {
+            appendIfUnique(
+                ArgoCoachAction(
+                    id: "coach-connect-wearable",
+                    title: "Wearable data is missing.",
+                    body: "Recovery and strain recommendations improve when Whoop, Garmin, or Apple Health data is current.",
+                    primaryLabel: "Review",
+                    kind: .recoveryHabit
+                )
+            )
+        }
+
+        return Array(actions.prefix(3))
+    }
 
     var body: some View {
         NavigationStack {
@@ -40,6 +70,10 @@ struct CoachView: View {
             .background(DesignSystem.Colors.background.ignoresSafeArea())
             .navigationBarHidden(true)
         }
+        .task { await loadContext() }
+        .onReceive(NotificationCenter.default.publisher(for: .argoDailyContextDidChange)) { _ in
+            Task { await loadContext() }
+        }
     }
 
     private var header: some View {
@@ -48,7 +82,7 @@ struct CoachView: View {
                 .font(DesignSystem.Typography.displayLargeSafe)
                 .foregroundColor(DesignSystem.Colors.primaryText)
 
-            Text("Ask about training, food, recovery, and how to structure the week.")
+            Text(context?.derived.summaryText ?? "Ask about training, food, recovery, and how to structure the week.")
                 .font(DesignSystem.Typography.bodyMedium)
                 .foregroundColor(DesignSystem.Colors.secondaryText)
         }
@@ -99,7 +133,7 @@ struct CoachView: View {
         }
     }
 
-    private func recommendationCard(_ recommendation: CoachRecommendation) -> some View {
+    private func recommendationCard(_ recommendation: ArgoCoachAction) -> some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
                 Text(recommendation.title)
@@ -112,7 +146,7 @@ struct CoachView: View {
             }
 
             HStack(spacing: DesignSystem.Spacing.sm) {
-                actionButton(recommendation.action, filled: true)
+                actionButton(recommendation.primaryLabel, filled: true)
                 actionButton("Edit", filled: false)
                 actionButton("Skip", filled: false)
             }
@@ -144,13 +178,14 @@ struct CoachView: View {
         }
         .buttonStyle(.plain)
     }
-}
 
-private struct CoachRecommendation: Identifiable {
-    let id = UUID()
-    let title: String
-    let body: String
-    let action: String
+    private func loadContext() async {
+        let refreshID = UUID()
+        contextRefreshID = refreshID
+        let nextContext = await contextService.refresh(for: Date())
+        guard contextRefreshID == refreshID else { return }
+        context = nextContext
+    }
 }
 
 #Preview {

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
@@ -96,17 +96,21 @@ struct MainTabView: View {
             .presentationDetents([.height(360), .medium])
             .presentationDragIndicator(.hidden)
         }
-        .sheet(isPresented: $showingMealLog, onDismiss: notifyDailyContextChanged) {
-            MealLogView(date: Date())
+        .sheet(isPresented: $showingMealLog) {
+            MealLogView(date: Date(), onSaved: notifyDailyContextChanged)
         }
-        .sheet(isPresented: $showingVoiceEntry, onDismiss: notifyDailyContextChanged) {
-            QuickEntryView(date: Date())
+        .sheet(isPresented: $showingVoiceEntry) {
+            QuickEntryView(date: Date()) { title, content in
+                await saveContextEntry(title: title, content: content, tags: ["voice"])
+            }
         }
-        .sheet(isPresented: $showingWorkoutReflection, onDismiss: notifyDailyContextChanged) {
-            WorkoutReflectionView(linkedPlan: nil, healthKitData: nil)
+        .sheet(isPresented: $showingWorkoutReflection) {
+            WorkoutReflectionView(linkedPlan: nil, healthKitData: nil, onSaved: notifyDailyContextChanged)
         }
-        .sheet(isPresented: $showingCheckIn, onDismiss: notifyDailyContextChanged) {
-            QuickEntryView(date: Date())
+        .sheet(isPresented: $showingCheckIn) {
+            QuickEntryView(date: Date()) { title, content in
+                await saveContextEntry(title: title, content: content, tags: ["check-in"])
+            }
         }
     }
 
@@ -213,6 +217,22 @@ struct MainTabView: View {
 
     private func notifyDailyContextChanged() {
         NotificationCenter.default.post(name: .argoDailyContextDidChange, object: nil)
+    }
+
+    private func saveContextEntry(title: String, content: String, tags: [String]) async {
+        do {
+            let titleParam: String? = title.isEmpty ? nil : title
+            _ = try await JournalEntriesService().createEntry(
+                title: titleParam,
+                content: content,
+                mood: nil,
+                energy: nil,
+                tags: tags
+            )
+            notifyDailyContextChanged()
+        } catch {
+            print("Failed to save context entry:", error)
+        }
     }
 }
 

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
@@ -96,16 +96,16 @@ struct MainTabView: View {
             .presentationDetents([.height(360), .medium])
             .presentationDragIndicator(.hidden)
         }
-        .sheet(isPresented: $showingMealLog) {
+        .sheet(isPresented: $showingMealLog, onDismiss: notifyDailyContextChanged) {
             MealLogView(date: Date())
         }
-        .sheet(isPresented: $showingVoiceEntry) {
+        .sheet(isPresented: $showingVoiceEntry, onDismiss: notifyDailyContextChanged) {
             QuickEntryView(date: Date())
         }
-        .sheet(isPresented: $showingWorkoutReflection) {
+        .sheet(isPresented: $showingWorkoutReflection, onDismiss: notifyDailyContextChanged) {
             WorkoutReflectionView(linkedPlan: nil, healthKitData: nil)
         }
-        .sheet(isPresented: $showingCheckIn) {
+        .sheet(isPresented: $showingCheckIn, onDismiss: notifyDailyContextChanged) {
             QuickEntryView(date: Date())
         }
     }
@@ -209,6 +209,10 @@ struct MainTabView: View {
                 showingCheckIn = true
             }
         }
+    }
+
+    private func notifyDailyContextChanged() {
+        NotificationCenter.default.post(name: .argoDailyContextDidChange, object: nil)
     }
 }
 

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
@@ -101,7 +101,7 @@ struct MainTabView: View {
         }
         .sheet(isPresented: $showingVoiceEntry) {
             QuickEntryView(date: Date()) { title, content in
-                await saveContextEntry(title: title, content: content, tags: ["voice"])
+                try await saveContextEntry(title: title, content: content, tags: ["voice"])
             }
         }
         .sheet(isPresented: $showingWorkoutReflection) {
@@ -109,7 +109,7 @@ struct MainTabView: View {
         }
         .sheet(isPresented: $showingCheckIn) {
             QuickEntryView(date: Date()) { title, content in
-                await saveContextEntry(title: title, content: content, tags: ["check-in"])
+                try await saveContextEntry(title: title, content: content, tags: ["check-in"])
             }
         }
     }
@@ -219,20 +219,16 @@ struct MainTabView: View {
         NotificationCenter.default.post(name: .argoDailyContextDidChange, object: nil)
     }
 
-    private func saveContextEntry(title: String, content: String, tags: [String]) async {
-        do {
-            let titleParam: String? = title.isEmpty ? nil : title
-            _ = try await JournalEntriesService().createEntry(
-                title: titleParam,
-                content: content,
-                mood: nil,
-                energy: nil,
-                tags: tags
-            )
-            notifyDailyContextChanged()
-        } catch {
-            print("Failed to save context entry:", error)
-        }
+    private func saveContextEntry(title: String, content: String, tags: [String]) async throws {
+        let titleParam: String? = title.isEmpty ? nil : title
+        _ = try await JournalEntriesService().createEntry(
+            title: titleParam,
+            content: content,
+            mood: nil,
+            energy: nil,
+            tags: tags
+        )
+        notifyDailyContextChanged()
     }
 }
 

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/MealLogView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/MealLogView.swift
@@ -38,11 +38,13 @@ struct MealLogView: View {
     private let mealsService: MealsServiceProtocol = MealsService()
     private let timeContext: DesignSystem.TimeContext = .neutral
     private let dateString: String
+    private let onSaved: (() -> Void)?
 
-    init(date: Date = Date()) {
+    init(date: Date = Date(), onSaved: (() -> Void)? = nil) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         self.dateString = formatter.string(from: date)
+        self.onSaved = onSaved
 
         // Auto-detect meal type from time of day
         let hour = Calendar.current.component(.hour, from: Date())
@@ -475,6 +477,7 @@ struct MealLogView: View {
                 editFat = String(format: "%.0f", meal.fatG)
                 isAnalyzing = false
                 HapticManager.success()
+                onSaved?()
             }
         } catch {
             await MainActor.run {
@@ -529,6 +532,7 @@ struct MealLogView: View {
                     displayedCarbs = updated.carbsG
                     displayedFat = updated.fatG
                     showEditValues = false
+                    onSaved?()
                 }
             }
         }

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/QuickEntryView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/QuickEntryView.swift
@@ -16,11 +16,12 @@ struct QuickEntryView: View {
     @State private var entryTitle = ""
     @State private var entryText = ""
     @State private var isSaving = false
+    @State private var saveErrorMessage: String?
     @FocusState private var isTitleFocused: Bool
     @FocusState private var isTextFieldFocused: Bool
-    
+
     let date: Date
-    var onSave: ((String, String) async -> Void)? // (title, content)
+    var onSave: ((String, String) async throws -> Void)? // (title, content)
     
     private var timeContext: DesignSystem.TimeContext { DesignSystem.TimeContext.current() }
     
@@ -127,6 +128,16 @@ struct QuickEntryView: View {
                     isTitleFocused = true
                 }
             }
+            .alert("Save Failed", isPresented: Binding(
+                get: { saveErrorMessage != nil },
+                set: { if !$0 { saveErrorMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) {
+                    saveErrorMessage = nil
+                }
+            } message: {
+                Text(saveErrorMessage ?? "")
+            }
         }
     }
     
@@ -170,20 +181,24 @@ struct QuickEntryView: View {
         
         // Use placeholder if title is empty
         let finalTitle = entryTitle.isEmpty ? "Quick Entry" : entryTitle
-        
-        // Save the entry with title
-        await onSave?(finalTitle, entryText)
-        
-        #if canImport(UIKit)
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
-        #endif
-        
-        isSaving = false
-        dismiss()
+
+        do {
+            // Save the entry with title
+            try await onSave?(finalTitle, entryText)
+
+            #if canImport(UIKit)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            #endif
+
+            isSaving = false
+            dismiss()
+        } catch {
+            saveErrorMessage = "Couldn’t save this entry. Please try again."
+            isSaving = false
+        }
     }
 }
 
 #Preview {
     QuickEntryView(date: Date())
 }
-

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift
@@ -26,10 +26,6 @@ struct TodayTimelineItem: Identifiable, Hashable {
 
     static func sortedRecentFirst(_ items: [TodayTimelineItem]) -> [TodayTimelineItem] {
         items.sorted { lhs, rhs in
-            if lhs.isUpcoming != rhs.isUpcoming {
-                return !lhs.isUpcoming && rhs.isUpcoming
-            }
-
             switch (lhs.timestamp, rhs.timestamp) {
             case let (left?, right?):
                 return left > right

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift
@@ -44,6 +44,42 @@ struct TodayTimelineItem: Identifiable, Hashable {
     }
 }
 
+extension TodayTimelineItem {
+    init(event: ArgoDailyEvent) {
+        self.init(
+            id: event.id,
+            kind: TodayTimelineItem.kind(for: event),
+            title: event.title,
+            subtitle: event.summary,
+            timestamp: event.timestamp,
+            displayTime: event.timestamp.map(Self.formattedEventTime) ?? "Planned",
+            isUpcoming: event.isUpcoming,
+            accent: event.requiresReview ? .attention : (event.isUpcoming ? .muted : .standard)
+        )
+    }
+
+    private static func kind(for event: ArgoDailyEvent) -> Kind {
+        switch event.type {
+        case .mealLogged:
+            return .meal
+        case .workoutPlanned, .workoutCompleted, .workoutReflected:
+            return .workout
+        case .checkInLogged:
+            return .checkIn
+        case .coachRecommendation:
+            return .coach
+        case .noteLogged, .wearableRecovery, .wearableSleep, .wearableStrain:
+            return .note
+        }
+    }
+
+    private static func formattedEventTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        return formatter.string(from: date)
+    }
+}
+
 enum TodayTimelineBuilder {
     static func makeItems(
         plans: [TrainingPlan],

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift
@@ -56,14 +56,15 @@ struct TodayView: View {
     private let onCoachTap: () -> Void
     private let contextService: DailyContextProviding
 
+    @MainActor
     init(
         onLogTap: @escaping () -> Void = {},
         onCoachTap: @escaping () -> Void = {},
-        contextService: DailyContextProviding = ClientDailyContextService()
+        contextService: DailyContextProviding? = nil
     ) {
         self.onLogTap = onLogTap
         self.onCoachTap = onCoachTap
-        self.contextService = contextService
+        self.contextService = contextService ?? ClientDailyContextService()
     }
 
     private var timeContext: DesignSystem.TimeContext {

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift
@@ -464,23 +464,19 @@ extension TodayView {
     @ViewBuilder
     private var quickEntrySheet: some View {
         QuickEntryView(date: Date()) { title, content in
-            do {
-                let titleParam: String? = title.isEmpty ? nil : title
-                let moodParam: Int? = nil
-                let energyParam: Int? = nil
-                let tagsParam: [String]? = nil
-                _ = try await journalService.createEntry(
-                    title: titleParam,
-                    content: content,
-                    mood: moodParam,
-                    energy: energyParam,
-                    tags: tagsParam
-                )
-                await loadJournalEntries()
-                await loadDailyContext(for: selectedDate)
-            } catch {
-                print("Failed to save journal entry:", error)
-            }
+            let titleParam: String? = title.isEmpty ? nil : title
+            let moodParam: Int? = nil
+            let energyParam: Int? = nil
+            let tagsParam: [String]? = nil
+            _ = try await journalService.createEntry(
+                title: titleParam,
+                content: content,
+                mood: moodParam,
+                energy: energyParam,
+                tags: tagsParam
+            )
+            await loadJournalEntries()
+            await loadDailyContext(for: selectedDate)
         }
     }
 

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift
@@ -35,6 +35,7 @@ struct TodayView: View {
     @State private var completedGoals: Set<Int> = []
     @State private var selectedTrainingPlan: TrainingPlan?
     @State private var trainingPlanToEdit: TrainingPlan?
+    @State private var dailyContext: ArgoDailyContext?
 
     // Workout reflection
     @State private var workoutReflectionPlan: TrainingPlan?
@@ -53,10 +54,16 @@ struct TodayView: View {
     private let mealsService: MealsServiceProtocol = MealsService()
     private let onLogTap: () -> Void
     private let onCoachTap: () -> Void
+    private let contextService: DailyContextProviding
 
-    init(onLogTap: @escaping () -> Void = {}, onCoachTap: @escaping () -> Void = {}) {
+    init(
+        onLogTap: @escaping () -> Void = {},
+        onCoachTap: @escaping () -> Void = {},
+        contextService: DailyContextProviding = ClientDailyContextService()
+    ) {
         self.onLogTap = onLogTap
         self.onCoachTap = onCoachTap
+        self.contextService = contextService
     }
 
     private var timeContext: DesignSystem.TimeContext {
@@ -99,6 +106,7 @@ struct TodayView: View {
             .refreshable {
                 await SupabaseManager.shared.replayPendingOpsWithBackoff()
                 await viewModel.refresh(for: selectedDate)
+                await loadDailyContext(for: selectedDate)
                 await loadJournalEntries()
                 await loadNutrition(for: selectedDate)
             }
@@ -113,12 +121,16 @@ struct TodayView: View {
                 if HealthKitService.shared.isAuthorized {
                     await HealthKitService.shared.fetchTodayData()
                 }
+                await loadDailyContext(for: selectedDate)
                 withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) {
                     cardsVisible = true
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.significantTimeChangeNotification)) { _ in
                 handlePotentialDayChange()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .argoDailyContextDidChange)) { _ in
+                Task { await loadDailyContext(for: selectedDate) }
             }
             .onChange(of: scenePhase) { phase in
                 if phase == .active {
@@ -155,6 +167,7 @@ struct TodayView: View {
             .sheet(isPresented: $showingAddActivity) {
                 TrainingPlanFormSheet(mode: .create, date: selectedDate, onSaved: {
                     await viewModel.load(date: selectedDate)
+                    await loadDailyContext(for: selectedDate)
                 })
             }
             .sheet(item: $selectedTrainingPlan) { plan in
@@ -163,6 +176,7 @@ struct TodayView: View {
             .sheet(item: $trainingPlanToEdit) { plan in
                 TrainingPlanFormSheet(mode: .edit, date: selectedDate, existingPlan: plan, onSaved: {
                     await viewModel.load(date: selectedDate)
+                    await loadDailyContext(for: selectedDate)
                 })
             }
             .sheet(item: $selectedJournalEntry) { entry in
@@ -177,7 +191,10 @@ struct TodayView: View {
                 }
             }
             .sheet(isPresented: $showingMealLog, onDismiss: {
-                Task { await loadNutrition(for: selectedDate) }
+                Task {
+                    await loadNutrition(for: selectedDate)
+                    await loadDailyContext(for: selectedDate)
+                }
             }) {
                 MealLogView(date: selectedDate)
             }
@@ -188,105 +205,59 @@ struct TodayView: View {
 // MARK: - Content Views
 extension TodayView {
     private var timelineItems: [TodayTimelineItem] {
-        TodayTimelineBuilder.makeItems(
-            plans: viewModel.sortedTrainingPlans,
-            nutritionSummary: nutritionSummary,
-            journalEntries: journalEntries,
-            morningCompletedAt: viewModel.entry.morningCompletedAt,
-            eveningCompletedAt: viewModel.entry.eveningCompletedAt
-        )
+        TodayTimelineItem.sortedRecentFirst((dailyContext?.events ?? []).map(TodayTimelineItem.init(event:)))
     }
 
     private var roundedRecoveryScore: Int? {
-        WhoopService.shared.dailyData?.recoveryScore.map { Int($0.rounded()) }
+        dailyContext?.whoop?.recoveryScore.map { Int($0.rounded()) }
     }
 
     private var sleepSummaryText: String {
-        guard let data = WhoopService.shared.dailyData else { return "--" }
-
+        guard let data = dailyContext?.whoop else { return "--" }
         if let minutes = data.sleepDurationMinutes {
             return formatMinutes(minutes)
         }
-
         if let performance = data.sleepPerformance {
             return "\(Int(performance.rounded()))%"
         }
-
         return "--"
     }
 
     private var fuelSummaryText: String {
-        guard let summary = nutritionSummary else { return "No meals" }
-        if summary.mealCount == 0 { return "No meals" }
-        return "\(summary.totalCalories) cal"
+        guard let nutrition = dailyContext?.nutrition else { return "No meals" }
+        return nutrition.mealCount == 0 ? "No meals" : "\(nutrition.totalCalories) cal"
     }
 
     private var loadSummaryText: String {
-        if let strain = WhoopService.shared.dailyData?.strainScore {
-            return String(format: "%.1f strain", strain)
+        switch dailyContext?.derived.trainingLoadStatus {
+        case .high:
+            return "High"
+        case .completed:
+            return "Complete"
+        case .planned:
+            return "Planned"
+        case .open:
+            return "Open"
+        case .unknown, .none:
+            return "--"
         }
-
-        let workoutCount = HealthKitService.shared.todayWorkouts.count
-        if workoutCount > 0 {
-            return "\(workoutCount) workout\(workoutCount == 1 ? "" : "s")"
-        }
-
-        return "Open"
     }
 
     private var planSummaryText: String {
-        let plans = viewModel.sortedTrainingPlans
+        let plans = dailyContext?.plannedWorkouts ?? []
         guard let firstPlan = plans.first else {
             return "No training plan yet. Add the key session, meals, and recovery block for the day."
         }
-
         let time = firstPlan.formattedStartTime ?? "Planned"
-        let remaining = plans.count - 1
-        if remaining > 0 {
-            return "\(firstPlan.activityType.displayName) at \(time), plus \(remaining) more item\(remaining == 1 ? "" : "s")."
-        }
-
         return "\(firstPlan.activityType.displayName) at \(time)."
     }
 
     private var nextActionText: String {
-        if !viewModel.entry.isMorningComplete {
-            return "Start with a quick check-in."
-        }
-
-        if nutritionSummary?.mealCount ?? 0 == 0 {
-            return "Log your first meal."
-        }
-
-        if let recovery = roundedRecoveryScore, recovery < 50 {
-            return "Keep training controlled."
-        }
-
-        if viewModel.sortedTrainingPlans.isEmpty {
-            return "Set today's training anchor."
-        }
-
-        return "Stay on the plan."
+        dailyContext?.derived.nextAction?.title ?? "Build today's context."
     }
 
     private var nextActionRationale: String {
-        if !viewModel.entry.isMorningComplete {
-            return "Argo needs a fast read on energy, stress, and the shape of the day before suggesting changes."
-        }
-
-        if nutritionSummary?.mealCount ?? 0 == 0 {
-            return "Food context makes the coach more useful for training load, recovery, and evening choices."
-        }
-
-        if let recovery = roundedRecoveryScore, recovery < 50 {
-            return "Recovery is below the green zone, so today's structure should protect tomorrow."
-        }
-
-        if viewModel.sortedTrainingPlans.isEmpty {
-            return "A simple time block is enough. The app can help you protect the session around work and meals."
-        }
-
-        return "Use the timeline to keep meals, workouts, notes, and recovery decisions in one place."
+        dailyContext?.derived.nextAction?.body ?? "Log meals, training, and reflections so Argo can coach from useful data."
     }
 
     @ViewBuilder
@@ -295,6 +266,7 @@ extension TodayView {
             .onChange(of: selectedDate) { _, newDate in
                 Task {
                     await viewModel.load(date: newDate)
+                    await loadDailyContext(for: newDate)
                     await loadJournalEntries()
                     await loadNutrition(for: newDate)
                     completedGoals = loadCompletedGoals(for: newDate)
@@ -505,6 +477,7 @@ extension TodayView {
                     tags: tagsParam
                 )
                 await loadJournalEntries()
+                await loadDailyContext(for: selectedDate)
             } catch {
                 print("Failed to save journal entry:", error)
             }
@@ -524,6 +497,7 @@ extension TodayView {
             onDelete: {
                 try? await plansService.remove(plan.id)
                 await viewModel.load(date: selectedDate)
+                await loadDailyContext(for: selectedDate)
             },
             onDismiss: {
                 selectedTrainingPlan = nil
@@ -549,6 +523,7 @@ extension TodayView {
                         tags: tagsParam
                     )
                     await loadJournalEntries()
+                    await loadDailyContext(for: selectedDate)
                 } catch {
                     print("Failed to update journal entry:", error)
                 }
@@ -557,6 +532,7 @@ extension TodayView {
                 do {
                     try await journalService.deleteEntry(id: entry.id)
                     await loadJournalEntries()
+                    await loadDailyContext(for: selectedDate)
                 } catch {
                     print("Failed to delete journal entry:", error)
                 }
@@ -570,6 +546,7 @@ extension TodayView {
     private func refreshData() {
         Task {
             await viewModel.load(date: selectedDate)
+            await loadDailyContext(for: selectedDate)
             await loadJournalEntries()
             await loadNutrition(for: selectedDate)
             await StreaksService.shared.fetchStreaks(force: true)
@@ -584,10 +561,17 @@ extension TodayView {
         selectedDate = newDay
         Task {
             await viewModel.load(date: newDay)
+            await loadDailyContext(for: newDay)
             await loadJournalEntries()
             await loadNutrition(for: newDay)
             completedGoals = loadCompletedGoals(for: newDay)
         }
+    }
+
+    private func loadDailyContext(for date: Date) async {
+        let context = await contextService.refresh(for: date)
+        guard Calendar.current.isDate(date, inSameDayAs: selectedDate) else { return }
+        dailyContext = context
     }
 
     private func loadCompletedGoals(for date: Date) -> Set<Int> {

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/WorkoutReflectionView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/WorkoutReflectionView.swift
@@ -37,6 +37,7 @@ struct WorkoutReflectionView: View {
 
     var linkedPlan: TrainingPlan?
     var healthKitData: PartialWorkoutData?
+    var onSaved: (() -> Void)? = nil
 
     private let timeContext: DesignSystem.TimeContext = .neutral
     private let totalSteps = 4
@@ -257,6 +258,7 @@ struct WorkoutReflectionView: View {
                 #if canImport(UIKit)
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
                 #endif
+                onSaved?()
                 showingCompletion = true
             }
             // Fetch post-workout insight after a brief delay (edge function needs time to generate)

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/WorkoutReflectionView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/WorkoutReflectionView.swift
@@ -247,6 +247,7 @@ struct WorkoutReflectionView: View {
             createdAt: nil,
             updatedAt: nil
         )
+        reflection.appleWorkoutId = appleWorkoutId
 
         if let plan = linkedPlan {
             reflection.trainingPlanId = plan.id

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyContextTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyContextTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoDailyContextTests {
+    @Test func eventsSortLoggedItemsNewestFirstBeforeUpcomingPlans() {
+        let base = Date(timeIntervalSince1970: 2_000)
+        let olderMeal = ArgoDailyEvent(
+            id: "meal-1",
+            source: .meal,
+            type: .mealLogged,
+            timestamp: base,
+            title: "Breakfast logged",
+            summary: "540 cal",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: "meal-1",
+            isUpcoming: false
+        )
+        let newerNote = ArgoDailyEvent(
+            id: "note-1",
+            source: .journal,
+            type: .noteLogged,
+            timestamp: base.addingTimeInterval(60),
+            title: "Voice note",
+            summary: "Legs feel heavy",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: "note-1",
+            isUpcoming: false
+        )
+        let upcomingPlan = ArgoDailyEvent(
+            id: "plan-1",
+            source: .trainingPlan,
+            type: .workoutPlanned,
+            timestamp: base.addingTimeInterval(120),
+            title: "Upcoming Strength",
+            summary: "60 min",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: "plan-1",
+            isUpcoming: true
+        )
+
+        let sorted = ArgoDailyEvent.sortedRecentFirst([olderMeal, upcomingPlan, newerNote])
+
+        #expect(sorted.map(\.id) == ["note-1", "meal-1", "plan-1"])
+    }
+
+    @Test func emptyContextHasStableDefaults() {
+        let date = Date(timeIntervalSince1970: 2_000)
+        let context = ArgoDailyContext.empty(date: date)
+
+        #expect(context.date == date)
+        #expect(context.events.isEmpty)
+        #expect(context.derived.recoveryStatus == .unknown)
+        #expect(context.derived.fuelStatus == .unknown)
+        #expect(context.derived.trainingLoadStatus == .unknown)
+        #expect(context.derived.missingContext.contains(.missingWearableData))
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyContextTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyContextTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import Your_Daily_Dose
 
 struct ArgoDailyContextTests {
-    @Test func eventsSortLoggedItemsNewestFirstBeforeUpcomingPlans() {
+    @Test func eventsSortByMostRecentTimestampFirst() {
         let base = Date(timeIntervalSince1970: 2_000)
         let olderMeal = ArgoDailyEvent(
             id: "meal-1",
@@ -47,7 +47,7 @@ struct ArgoDailyContextTests {
 
         let sorted = ArgoDailyEvent.sortedRecentFirst([olderMeal, upcomingPlan, newerNote])
 
-        #expect(sorted.map(\.id) == ["note-1", "meal-1", "plan-1"])
+        #expect(sorted.map(\.id) == ["plan-1", "note-1", "meal-1"])
     }
 
     @Test func emptyContextHasStableDefaults() {

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyEventMapperTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyEventMapperTests.swift
@@ -66,4 +66,26 @@ struct ArgoDailyEventMapperTests {
         #expect(event.summary.contains("Moderate"))
         #expect(event.isUpcoming)
     }
+
+    @Test func unscheduledTrainingPlanUsesPlannedDisplayWithoutMidnightTimestamp() {
+        let date = Date(timeIntervalSince1970: 86_400)
+        let plan = TrainingPlan(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000203")!,
+            userId: UUID(),
+            date: date,
+            sequence: 0,
+            trainingType: "running",
+            startTime: nil,
+            intensity: "easy",
+            durationMinutes: 30,
+            notes: nil,
+            createdAt: nil,
+            updatedAt: nil
+        )
+
+        let event = ArgoDailyEventMapper.makeTrainingPlanEvent(plan, now: Date(timeIntervalSince1970: 0))
+
+        #expect(event.timestamp == nil)
+        #expect(event.isUpcoming)
+    }
 }

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyEventMapperTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyEventMapperTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoDailyEventMapperTests {
+    @Test func mapsMealsIntoReviewableMealEventsWhenConfidenceIsLow() {
+        let createdAt = Date(timeIntervalSince1970: 3_000)
+        let meal = Meal(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000101")!,
+            userId: UUID(),
+            date: createdAt,
+            mealType: "lunch",
+            photoStoragePath: nil,
+            photoUrl: nil,
+            foodDescription: "Chicken bowl",
+            estimatedCalories: 740,
+            estimatedProteinG: 48,
+            estimatedCarbsG: 82,
+            estimatedFatG: 24,
+            estimatedFiberG: nil,
+            aiConfidence: 0.52,
+            userCalories: nil,
+            userProteinG: nil,
+            userCarbsG: nil,
+            userFatG: nil,
+            userNotes: nil,
+            createdAt: createdAt,
+            updatedAt: nil
+        )
+
+        let event = ArgoDailyEventMapper.makeMealEvent(meal)
+
+        #expect(event.id == "meal-00000000-0000-0000-0000-000000000101")
+        #expect(event.source == .meal)
+        #expect(event.type == .mealLogged)
+        #expect(event.title == "Lunch logged")
+        #expect(event.summary.contains("740 cal"))
+        #expect(event.summary.contains("48g protein"))
+        #expect(event.confidence == 0.52)
+        #expect(event.requiresReview)
+    }
+
+    @Test func mapsTrainingPlansIntoUpcomingPlanEvents() {
+        let date = Date(timeIntervalSince1970: 86_400)
+        let plan = TrainingPlan(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000202")!,
+            userId: UUID(),
+            date: date,
+            sequence: 0,
+            trainingType: "strength_training",
+            startTime: "17:30:00",
+            intensity: "moderate",
+            durationMinutes: 60,
+            notes: "Lower body",
+            createdAt: nil,
+            updatedAt: nil
+        )
+
+        let event = ArgoDailyEventMapper.makeTrainingPlanEvent(plan, now: Date(timeIntervalSince1970: 0))
+
+        #expect(event.id == "plan-00000000-0000-0000-0000-000000000202")
+        #expect(event.source == .trainingPlan)
+        #expect(event.type == .workoutPlanned)
+        #expect(event.title == "Upcoming Strength Training")
+        #expect(event.summary.contains("60 min"))
+        #expect(event.summary.contains("Moderate"))
+        #expect(event.isUpcoming)
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailySignalsEvaluatorTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailySignalsEvaluatorTests.swift
@@ -170,6 +170,73 @@ struct ArgoDailySignalsEvaluatorTests {
         #expect(!durationSignals.missingContext.contains(.noPlan))
     }
 
+    @Test func sourceFailuresSuppressUserActionGapsForUnavailableSources() {
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: Date(timeIntervalSince1970: 4_500),
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            sourceFailures: [.missingDailyEntryData, .missingTrainingPlanData]
+        )
+
+        #expect(signals.missingContext.contains(.missingDailyEntryData))
+        #expect(signals.missingContext.contains(.missingTrainingPlanData))
+        #expect(!signals.missingContext.contains(.noMorningCheckIn))
+        #expect(!signals.missingContext.contains(.noPlan))
+    }
+
+    @Test func morningCheckInGapProducesCoachActionAfterHigherPriorityGapsAreResolved() {
+        let date = Date(timeIntervalSince1970: 4_600)
+        var entry = DailyEntry(userId: UUID(), date: date)
+        entry.plannedTrainingTime = "18:00"
+        let nutrition = DailyNutritionSummary(
+            date: "1970-01-01",
+            mealCount: 1,
+            totalCalories: 700,
+            totalProteinG: 55,
+            totalCarbsG: 70,
+            totalFatG: 20,
+            totalFiberG: 8,
+            meals: []
+        )
+        let whoop = WhoopDailyData(
+            id: nil,
+            userId: nil,
+            date: date,
+            recoveryScore: 70,
+            recoveryZone: .green,
+            sleepPerformance: nil,
+            sleepDurationMinutes: nil,
+            sleepEfficiency: nil,
+            sleepStages: nil,
+            respiratoryRate: nil,
+            skinTempDelta: nil,
+            hrv: nil,
+            restingHr: nil,
+            strainScore: nil,
+            fetchedAt: date
+        )
+
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: entry,
+            nutrition: nutrition,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: whoop,
+            sourceFailures: []
+        )
+
+        #expect(signals.missingContext.contains(.noMorningCheckIn))
+        #expect(signals.nextAction?.kind == .checkIn)
+    }
+
     private func makeHealthKitWorkout(
         id: String,
         date: Date,

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailySignalsEvaluatorTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailySignalsEvaluatorTests.swift
@@ -1,0 +1,224 @@
+import Foundation
+import HealthKit
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoDailySignalsEvaluatorTests {
+    @Test func missingDataProducesMissingContextAndLogMealAction() {
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: Date(timeIntervalSince1970: 4_000),
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            sourceFailures: []
+        )
+
+        #expect(signals.recoveryStatus == .unknown)
+        #expect(signals.fuelStatus == .notStarted)
+        #expect(signals.trainingLoadStatus == .open)
+        #expect(signals.missingContext.contains(.noMeals))
+        #expect(signals.missingContext.contains(.noPlan))
+        #expect(signals.missingContext.contains(.missingWearableData))
+        #expect(signals.nextAction?.kind == .logMeal)
+    }
+
+    @Test func lowRecoveryWithPlanRecommendsAdjustTraining() {
+        let date = Date(timeIntervalSince1970: 4_000)
+        let whoop = WhoopDailyData(
+            id: nil,
+            userId: nil,
+            date: date,
+            recoveryScore: 32,
+            recoveryZone: .red,
+            sleepPerformance: nil,
+            sleepDurationMinutes: nil,
+            sleepEfficiency: nil,
+            sleepStages: nil,
+            respiratoryRate: nil,
+            skinTempDelta: nil,
+            hrv: nil,
+            restingHr: nil,
+            strainScore: nil,
+            fetchedAt: date
+        )
+        let plan = TrainingPlan(
+            id: UUID(),
+            userId: UUID(),
+            date: date,
+            sequence: 0,
+            trainingType: "running",
+            startTime: "18:00:00",
+            intensity: "hard",
+            durationMinutes: 45,
+            notes: nil,
+            createdAt: nil,
+            updatedAt: nil
+        )
+
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [plan],
+            healthKitWorkouts: [],
+            whoop: whoop,
+            sourceFailures: []
+        )
+
+        #expect(signals.recoveryStatus == .low)
+        #expect(signals.trainingLoadStatus == .planned)
+        #expect(signals.nextAction?.kind == .adjustTraining)
+    }
+
+    @Test func emptyValidSourcesDoNotCreateSourceFailureFlags() {
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: Date(timeIntervalSince1970: 4_100),
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            sourceFailures: []
+        )
+
+        #expect(!signals.missingContext.contains(.missingNutritionData))
+        #expect(!signals.missingContext.contains(.missingJournalData))
+        #expect(!signals.missingContext.contains(.missingReflectionData))
+        #expect(signals.missingContext.contains(.noMeals))
+    }
+
+    @Test func linkedHealthKitReflectionDoesNotDoubleCountWorkoutLoad() {
+        let date = Date(timeIntervalSince1970: 4_200)
+        let workout = makeHealthKitWorkout(id: "apple-workout-1", date: date, durationMinutes: 45)
+        let reflection = makeWorkoutReflection(date: date, appleWorkoutId: workout.id, durationMinutes: 45)
+
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [reflection],
+            plannedWorkouts: [],
+            healthKitWorkouts: [workout],
+            whoop: nil,
+            sourceFailures: []
+        )
+
+        #expect(signals.trainingLoadStatus == .completed)
+        #expect(!signals.missingContext.contains(.missingWorkoutReflection))
+    }
+
+    @Test func unlinkedReflectionDoesNotClearHealthKitMissingReflection() {
+        let date = Date(timeIntervalSince1970: 4_300)
+        let workout = makeHealthKitWorkout(id: "apple-workout-1", date: date, durationMinutes: 45)
+        let reflection = makeWorkoutReflection(date: date, appleWorkoutId: nil, durationMinutes: 45)
+
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [reflection],
+            plannedWorkouts: [],
+            healthKitWorkouts: [workout],
+            whoop: nil,
+            sourceFailures: []
+        )
+
+        #expect(signals.missingContext.contains(.missingWorkoutReflection))
+    }
+
+    @Test func legacyDailyEntryPlanFieldsSatisfyNoPlanCheck() {
+        let date = Date(timeIntervalSince1970: 4_400)
+        var timeOnlyEntry = DailyEntry(userId: UUID(), date: date)
+        timeOnlyEntry.plannedTrainingTime = "18:00"
+        var durationOnlyEntry = DailyEntry(userId: UUID(), date: date)
+        durationOnlyEntry.plannedDuration = 30
+
+        let timeSignals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: timeOnlyEntry,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            sourceFailures: []
+        )
+        let durationSignals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: durationOnlyEntry,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            sourceFailures: []
+        )
+
+        #expect(!timeSignals.missingContext.contains(.noPlan))
+        #expect(!durationSignals.missingContext.contains(.noPlan))
+    }
+
+    private func makeHealthKitWorkout(
+        id: String,
+        date: Date,
+        durationMinutes: Int
+    ) -> HKWorkoutSummary {
+        HKWorkoutSummary(
+            id: id,
+            activityType: .running,
+            startDate: date,
+            endDate: date.addingTimeInterval(TimeInterval(durationMinutes * 60)),
+            durationMinutes: durationMinutes,
+            totalCalories: 400,
+            averageHeartRate: nil,
+            maxHeartRate: nil
+        )
+    }
+
+    private func makeWorkoutReflection(
+        date: Date,
+        appleWorkoutId: String?,
+        durationMinutes: Int?
+    ) -> WorkoutReflection {
+        WorkoutReflection(
+            id: UUID(),
+            userId: UUID(),
+            date: date,
+            workoutSequence: 0,
+            trainingFeeling: nil,
+            whatWentWell: nil,
+            whatToImprove: nil,
+            energyLevel: nil,
+            focusLevel: nil,
+            workoutType: nil,
+            workoutIntensity: nil,
+            durationMinutes: durationMinutes,
+            caloriesBurned: nil,
+            averageHr: nil,
+            maxHr: nil,
+            strainScore: nil,
+            recoveryScore: nil,
+            sleepPerformance: nil,
+            hrv: nil,
+            restingHr: nil,
+            stravaActivityId: nil,
+            appleWorkoutId: appleWorkoutId,
+            whoopActivityId: nil,
+            createdAt: nil,
+            updatedAt: nil,
+            trainingPlanId: nil
+        )
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+@MainActor
+struct ClientDailyContextServiceTests {
+    @Test func returnsPartialContextWhenMealsFail() async {
+        let date = Date(timeIntervalSince1970: 5_000)
+        let service = ClientDailyContextService(
+            mealsService: FailingMealsService(),
+            journalService: EmptyJournalEntriesService(),
+            workoutReflectionsService: EmptyWorkoutReflectionsService(),
+            dailyEntriesService: EmptyDailyEntriesService(),
+            whoopDataProvider: { nil },
+            healthKitWorkoutsProvider: { [] }
+        )
+
+        let context = await service.context(for: date)
+
+        #expect(context.date == date)
+        #expect(context.nutrition == nil)
+        #expect(context.derived.missingContext.contains(.missingNutritionData))
+        #expect(context.derived.missingContext.contains(.noMeals))
+    }
+}
+
+private enum TestServiceError: Error {
+    case failed
+}
+
+private struct FailingMealsService: MealsServiceProtocol {
+    func uploadMeal(photoData: Data, mimeType: String, mealType: String, date: String) async throws -> Meal {
+        throw TestServiceError.failed
+    }
+
+    func getMeals(date: String) async throws -> [Meal] {
+        throw TestServiceError.failed
+    }
+
+    func updateMeal(id: UUID, updates: [String: Any]) async throws -> Meal {
+        throw TestServiceError.failed
+    }
+
+    func deleteMeal(id: UUID) async throws {
+        throw TestServiceError.failed
+    }
+
+    func getDailyNutrition(date: String) async throws -> DailyNutritionSummary {
+        throw TestServiceError.failed
+    }
+}
+
+private struct EmptyJournalEntriesService: JournalEntriesServiceProtocol {
+    func fetchEntries(page: Int, limit: Int) async throws -> (entries: [JournalEntry], hasNext: Bool) {
+        ([], false)
+    }
+
+    func fetchEntry(id: UUID) async throws -> JournalEntry {
+        throw TestServiceError.failed
+    }
+
+    func createEntry(title: String?, content: String, mood: Int?, energy: Int?, tags: [String]?) async throws -> JournalEntry {
+        throw TestServiceError.failed
+    }
+
+    func updateEntry(id: UUID, title: String?, content: String?, mood: Int?, energy: Int?, tags: [String]?) async throws -> JournalEntry {
+        throw TestServiceError.failed
+    }
+
+    func deleteEntry(id: UUID) async throws {}
+
+    func fetchEntriesForDate(_ date: Date) async throws -> [JournalEntry] {
+        []
+    }
+}
+
+private struct EmptyWorkoutReflectionsService: WorkoutReflectionsServiceProtocol {
+    func create(_ reflection: WorkoutReflection) async throws -> WorkoutReflection {
+        reflection
+    }
+
+    func list(date: Date?) async throws -> [WorkoutReflection] {
+        []
+    }
+
+    func get(id: UUID) async throws -> WorkoutReflection? {
+        nil
+    }
+
+    func update(_ reflection: WorkoutReflection) async throws -> WorkoutReflection {
+        reflection
+    }
+
+    func delete(id: UUID) async throws {}
+
+    func getStats(days: Int) async throws -> WorkoutReflectionStats {
+        WorkoutReflectionStats(
+            periodDays: days,
+            totalWorkouts: 0,
+            avgTrainingFeeling: 0,
+            avgEnergyLevel: 0,
+            avgFocusLevel: 0,
+            totalMinutes: 0,
+            workoutTypeDistribution: [:],
+            workoutsPerWeek: 0
+        )
+    }
+}
+
+private struct EmptyDailyEntriesService: DailyEntriesServiceProtocol {
+    func getEntry(for date: Date) async throws -> DailyEntry? {
+        nil
+    }
+
+    func getTrainingPlans(for date: Date) async throws -> [TrainingPlan] {
+        []
+    }
+
+    func getQuote(for date: Date) async throws -> Quote? {
+        nil
+    }
+
+    func completeMorning(for entry: DailyEntry) async throws -> DailyEntry {
+        entry
+    }
+
+    func completeEvening(for entry: DailyEntry) async throws -> DailyEntry {
+        entry
+    }
+
+    func getEntriesBatch(for dates: [Date]) async throws -> [String: DailyEntry] {
+        [:]
+    }
+
+    func getEntriesWithPlansBatch(for dates: [Date]) async throws -> (entries: [String: DailyEntry], plans: [String: [TrainingPlan]]) {
+        ([:], [:])
+    }
+
+    @MainActor func prefetchEntriesAround(date: Date, range: Int) {}
+}

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift
@@ -11,8 +11,8 @@ struct ClientDailyContextServiceTests {
             journalService: EmptyJournalEntriesService(),
             workoutReflectionsService: EmptyWorkoutReflectionsService(),
             dailyEntriesService: EmptyDailyEntriesService(),
-            whoopDataProvider: { nil },
-            healthKitWorkoutsProvider: { [] }
+            whoopDataProvider: { _ in nil },
+            healthKitWorkoutsProvider: { _ in [] }
         )
 
         let context = await service.context(for: date)
@@ -21,6 +21,31 @@ struct ClientDailyContextServiceTests {
         #expect(context.nutrition == nil)
         #expect(context.derived.missingContext.contains(.missingNutritionData))
         #expect(context.derived.missingContext.contains(.noMeals))
+    }
+
+    @Test func passesRequestedDateToWearableProviders() async {
+        let requestedDate = Date(timeIntervalSince1970: 9_000)
+        var whoopDate: Date?
+        var healthDate: Date?
+        let service = ClientDailyContextService(
+            mealsService: EmptyMealsService(),
+            journalService: EmptyJournalEntriesService(),
+            workoutReflectionsService: EmptyWorkoutReflectionsService(),
+            dailyEntriesService: EmptyDailyEntriesService(),
+            whoopDataProvider: { date in
+                whoopDate = date
+                return nil
+            },
+            healthKitWorkoutsProvider: { date in
+                healthDate = date
+                return []
+            }
+        )
+
+        _ = await service.context(for: requestedDate)
+
+        #expect(whoopDate == requestedDate)
+        #expect(healthDate == requestedDate)
     }
 }
 
@@ -47,6 +72,35 @@ private struct FailingMealsService: MealsServiceProtocol {
 
     func getDailyNutrition(date: String) async throws -> DailyNutritionSummary {
         throw TestServiceError.failed
+    }
+}
+
+private struct EmptyMealsService: MealsServiceProtocol {
+    func uploadMeal(photoData: Data, mimeType: String, mealType: String, date: String) async throws -> Meal {
+        throw TestServiceError.failed
+    }
+
+    func getMeals(date: String) async throws -> [Meal] {
+        []
+    }
+
+    func updateMeal(id: UUID, updates: [String: Any]) async throws -> Meal {
+        throw TestServiceError.failed
+    }
+
+    func deleteMeal(id: UUID) async throws {}
+
+    func getDailyNutrition(date: String) async throws -> DailyNutritionSummary {
+        DailyNutritionSummary(
+            date: date,
+            mealCount: 0,
+            totalCalories: 0,
+            totalProteinG: 0,
+            totalCarbsG: 0,
+            totalFatG: 0,
+            totalFiberG: 0,
+            meals: []
+        )
     }
 }
 

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift
@@ -47,6 +47,25 @@ struct ClientDailyContextServiceTests {
         #expect(whoopDate == requestedDate)
         #expect(healthDate == requestedDate)
     }
+
+    @Test func marksDailyEntryAndPlanSourceFailuresSeparately() async {
+        let date = Date(timeIntervalSince1970: 9_500)
+        let service = ClientDailyContextService(
+            mealsService: EmptyMealsService(),
+            journalService: EmptyJournalEntriesService(),
+            workoutReflectionsService: EmptyWorkoutReflectionsService(),
+            dailyEntriesService: FailingDailyEntriesService(),
+            whoopDataProvider: { _ in nil },
+            healthKitWorkoutsProvider: { _ in [] }
+        )
+
+        let context = await service.context(for: date)
+
+        #expect(context.derived.missingContext.contains(.missingDailyEntryData))
+        #expect(context.derived.missingContext.contains(.missingTrainingPlanData))
+        #expect(!context.derived.missingContext.contains(.noMorningCheckIn))
+        #expect(!context.derived.missingContext.contains(.noPlan))
+    }
 }
 
 private enum TestServiceError: Error {
@@ -188,6 +207,38 @@ private struct EmptyDailyEntriesService: DailyEntriesServiceProtocol {
 
     func getEntriesWithPlansBatch(for dates: [Date]) async throws -> (entries: [String: DailyEntry], plans: [String: [TrainingPlan]]) {
         ([:], [:])
+    }
+
+    @MainActor func prefetchEntriesAround(date: Date, range: Int) {}
+}
+
+private struct FailingDailyEntriesService: DailyEntriesServiceProtocol {
+    func getEntry(for date: Date) async throws -> DailyEntry? {
+        throw TestServiceError.failed
+    }
+
+    func getTrainingPlans(for date: Date) async throws -> [TrainingPlan] {
+        throw TestServiceError.failed
+    }
+
+    func getQuote(for date: Date) async throws -> Quote? {
+        throw TestServiceError.failed
+    }
+
+    func completeMorning(for entry: DailyEntry) async throws -> DailyEntry {
+        throw TestServiceError.failed
+    }
+
+    func completeEvening(for entry: DailyEntry) async throws -> DailyEntry {
+        throw TestServiceError.failed
+    }
+
+    func getEntriesBatch(for dates: [Date]) async throws -> [String: DailyEntry] {
+        throw TestServiceError.failed
+    }
+
+    func getEntriesWithPlansBatch(for dates: [Date]) async throws -> (entries: [String: DailyEntry], plans: [String: [TrainingPlan]]) {
+        throw TestServiceError.failed
     }
 
     @MainActor func prefetchEntriesAround(date: Date, range: Int) {}

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/TodayTimelineItemTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/TodayTimelineItemTests.swift
@@ -3,6 +3,31 @@ import Testing
 @testable import Your_Daily_Dose
 
 struct TodayTimelineItemTests {
+    @Test func adaptsArgoEventIntoTimelineItem() {
+        let timestamp = Date(timeIntervalSince1970: 6_000)
+        let event = ArgoDailyEvent(
+            id: "meal-1",
+            source: .meal,
+            type: .mealLogged,
+            timestamp: timestamp,
+            title: "Lunch logged",
+            summary: "740 cal · 48g protein",
+            payload: [:],
+            confidence: 0.8,
+            requiresReview: false,
+            sourceRecordId: "meal-1",
+            isUpcoming: false
+        )
+
+        let item = TodayTimelineItem(event: event)
+
+        #expect(item.id == "meal-1")
+        #expect(item.kind == .meal)
+        #expect(item.title == "Lunch logged")
+        #expect(item.subtitle == "740 cal · 48g protein")
+        #expect(item.timestamp == timestamp)
+    }
+
     @Test func recentFirstSortsDatedItemsBeforeUpcomingItems() {
         let base = Date(timeIntervalSince1970: 1_000)
         let old = TodayTimelineItem(

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/TodayTimelineItemTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/TodayTimelineItemTests.swift
@@ -28,7 +28,7 @@ struct TodayTimelineItemTests {
         #expect(item.timestamp == timestamp)
     }
 
-    @Test func recentFirstSortsDatedItemsBeforeUpcomingItems() {
+    @Test func recentFirstSortsByTimestampAcrossLoggedAndUpcomingItems() {
         let base = Date(timeIntervalSince1970: 1_000)
         let old = TodayTimelineItem(
             id: "old",
@@ -63,7 +63,7 @@ struct TodayTimelineItemTests {
 
         let sorted = TodayTimelineItem.sortedRecentFirst([old, upcoming, recent])
 
-        #expect(sorted.map(\.id) == ["recent", "old", "upcoming"])
+        #expect(sorted.map(\.id) == ["upcoming", "recent", "old"])
     }
 
     @Test func buildsMealItemsFromNutritionSummary() {

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/WorkoutReflectionPayloadBuilderTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/WorkoutReflectionPayloadBuilderTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct WorkoutReflectionPayloadBuilderTests {
+    @Test func createPayloadIncludesWearableActivityLinks() {
+        var reflection = WorkoutReflection(
+            id: UUID(),
+            userId: UUID(),
+            date: Date(timeIntervalSince1970: 7_000),
+            workoutSequence: 1,
+            trainingFeeling: 4,
+            whatWentWell: "Stayed smooth",
+            whatToImprove: "Fuel earlier",
+            energyLevel: 4,
+            focusLevel: 5,
+            workoutType: "running",
+            workoutIntensity: "moderate",
+            durationMinutes: 45,
+            createdAt: nil,
+            updatedAt: nil
+        )
+        reflection.appleWorkoutId = "apple-workout-123"
+        reflection.stravaActivityId = "strava-123"
+        reflection.whoopActivityId = "whoop-123"
+
+        let payload = WorkoutReflectionPayloadBuilder.createPayload(from: reflection)
+
+        #expect(payload["apple_workout_id"] as? String == "apple-workout-123")
+        #expect(payload["strava_activity_id"] as? String == "strava-123")
+        #expect(payload["whoop_activity_id"] as? String == "whoop-123")
+    }
+}

--- a/docs/superpowers/plans/2026-04-27-hybrid-daily-context-pipeline.md
+++ b/docs/superpowers/plans/2026-04-27-hybrid-daily-context-pipeline.md
@@ -1,0 +1,1558 @@
+# Hybrid Daily Context Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Argo's hybrid daily context pipeline so Today and Coach read one normalized daily context while preserving existing meal, journal, workout, plan, Whoop, and HealthKit persistence.
+
+**Architecture:** Add a client-side context model that mirrors a future backend event stream, then build a provider that aggregates existing services into that model. Today and Coach consume `DailyContextProviding` instead of directly composing every source themselves, and log dismissals trigger context refreshes through a lightweight notification.
+
+**Tech Stack:** Swift 5, SwiftUI, Swift Testing, existing iOS app services, existing Supabase-backed API client, HealthKit service, Whoop service.
+
+---
+
+## File Structure
+
+- Create `DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift`
+  - Owns `ArgoDailyContext`, `ArgoDailyEvent`, source/type enums, derived signal enums, `ArgoCoachAction`, and refresh notification name.
+- Create `DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift`
+  - Converts existing domain records into normalized events.
+- Create `DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailySignalsEvaluator.swift`
+  - Derives recovery, fuel, load, missing-context flags, summary text, and next action.
+- Create `DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift`
+  - Implements `DailyContextProviding` using existing services and partial-failure behavior.
+- Modify `DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift`
+  - Add an adapter from `ArgoDailyEvent` to `TodayTimelineItem`.
+- Modify `DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift`
+  - Load and refresh `ArgoDailyContext`; feed the brief and timeline from context.
+- Modify `DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift`
+  - Load and display context-aware summary and action cards.
+- Modify `DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift`
+  - Post a context refresh notification after log sheets dismiss.
+- Add tests:
+  - `DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyContextTests.swift`
+  - `DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyEventMapperTests.swift`
+  - `DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailySignalsEvaluatorTests.swift`
+  - `DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift`
+
+## Verification Command
+
+Use this command after each test task on a machine with an installed iOS Simulator runtime:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO
+```
+
+Expected final result: tests pass. If this local machine still reports `No available simulator runtimes for platform iphonesimulator`, record that as an environment failure and also run `git diff --check` before committing.
+
+---
+
+### Task 1: Add Daily Context Models
+
+**Files:**
+- Create: `DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift`
+- Test: `DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyContextTests.swift`
+
+- [ ] **Step 1: Write the failing model tests**
+
+Add:
+
+```swift
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoDailyContextTests {
+    @Test func eventsSortLoggedItemsNewestFirstBeforeUpcomingPlans() {
+        let base = Date(timeIntervalSince1970: 2_000)
+        let olderMeal = ArgoDailyEvent(
+            id: "meal-1",
+            source: .meal,
+            type: .mealLogged,
+            timestamp: base,
+            title: "Breakfast logged",
+            summary: "540 cal",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: "meal-1",
+            isUpcoming: false
+        )
+        let newerNote = ArgoDailyEvent(
+            id: "note-1",
+            source: .journal,
+            type: .noteLogged,
+            timestamp: base.addingTimeInterval(60),
+            title: "Voice note",
+            summary: "Legs feel heavy",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: "note-1",
+            isUpcoming: false
+        )
+        let upcomingPlan = ArgoDailyEvent(
+            id: "plan-1",
+            source: .trainingPlan,
+            type: .workoutPlanned,
+            timestamp: base.addingTimeInterval(120),
+            title: "Upcoming Strength",
+            summary: "60 min",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: "plan-1",
+            isUpcoming: true
+        )
+
+        let sorted = ArgoDailyEvent.sortedRecentFirst([olderMeal, upcomingPlan, newerNote])
+
+        #expect(sorted.map(\.id) == ["note-1", "meal-1", "plan-1"])
+    }
+
+    @Test func emptyContextHasStableDefaults() {
+        let date = Date(timeIntervalSince1970: 2_000)
+        let context = ArgoDailyContext.empty(date: date)
+
+        #expect(context.date == date)
+        #expect(context.events.isEmpty)
+        #expect(context.derived.recoveryStatus == .unknown)
+        #expect(context.derived.fuelStatus == .unknown)
+        #expect(context.derived.trainingLoadStatus == .unknown)
+        #expect(context.derived.missingContext.contains(.missingWearableData))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO -only-testing:"Your Daily DoseTests/ArgoDailyContextTests"
+```
+
+Expected: FAIL with errors like `Cannot find 'ArgoDailyEvent' in scope`.
+
+- [ ] **Step 3: Add the context model implementation**
+
+Create `ArgoDailyContext.swift`:
+
+```swift
+import Foundation
+
+struct ArgoDailyContext {
+    let date: Date
+    let dailyEntry: DailyEntry?
+    let events: [ArgoDailyEvent]
+    let nutrition: DailyNutritionSummary?
+    let journalEntries: [JournalEntry]
+    let workoutReflections: [WorkoutReflection]
+    let plannedWorkouts: [TrainingPlan]
+    let healthKitWorkouts: [HKWorkoutSummary]
+    let whoop: WhoopDailyData?
+    let derived: ArgoDailySignals
+
+    static func empty(date: Date, sourceFailures: Set<MissingContextFlag> = []) -> ArgoDailyContext {
+        ArgoDailyContext(
+            date: date,
+            dailyEntry: nil,
+            events: [],
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            derived: ArgoDailySignals(
+                recoveryStatus: .unknown,
+                fuelStatus: .unknown,
+                trainingLoadStatus: .unknown,
+                missingContext: sourceFailures.union([.missingWearableData]),
+                nextAction: nil,
+                summaryText: "No daily context loaded yet."
+            )
+        )
+    }
+}
+
+struct ArgoDailyEvent: Identifiable {
+    let id: String
+    let source: ArgoDailyEventSource
+    let type: ArgoDailyEventType
+    let timestamp: Date?
+    let title: String
+    let summary: String
+    let payload: [String: AnyCodable]
+    let confidence: Double?
+    let requiresReview: Bool
+    let sourceRecordId: String?
+    let isUpcoming: Bool
+
+    static func sortedRecentFirst(_ events: [ArgoDailyEvent]) -> [ArgoDailyEvent] {
+        events.sorted { lhs, rhs in
+            if lhs.isUpcoming != rhs.isUpcoming {
+                return !lhs.isUpcoming && rhs.isUpcoming
+            }
+
+            switch (lhs.timestamp, rhs.timestamp) {
+            case let (left?, right?):
+                return left > right
+            case (.some, .none):
+                return true
+            case (.none, .some):
+                return false
+            case (.none, .none):
+                return lhs.title < rhs.title
+            }
+        }
+    }
+}
+
+enum ArgoDailyEventSource: String, Codable, Sendable {
+    case meal
+    case journal
+    case workoutReflection
+    case trainingPlan
+    case healthKit
+    case whoop
+    case coach
+    case manual
+}
+
+enum ArgoDailyEventType: String, Codable, Sendable {
+    case mealLogged
+    case noteLogged
+    case checkInLogged
+    case workoutPlanned
+    case workoutCompleted
+    case workoutReflected
+    case wearableRecovery
+    case wearableSleep
+    case wearableStrain
+    case coachRecommendation
+}
+
+struct ArgoDailySignals: Sendable {
+    let recoveryStatus: RecoveryStatus
+    let fuelStatus: FuelStatus
+    let trainingLoadStatus: TrainingLoadStatus
+    let missingContext: Set<MissingContextFlag>
+    let nextAction: ArgoCoachAction?
+    let summaryText: String
+}
+
+enum RecoveryStatus: String, Sendable {
+    case unknown
+    case low
+    case moderate
+    case ready
+}
+
+enum FuelStatus: String, Sendable {
+    case unknown
+    case notStarted
+    case underFueled
+    case onTrack
+}
+
+enum TrainingLoadStatus: String, Sendable {
+    case unknown
+    case open
+    case planned
+    case completed
+    case high
+}
+
+enum MissingContextFlag: String, Hashable, Sendable {
+    case noMeals
+    case noPlan
+    case noMorningCheckIn
+    case missingWorkoutReflection
+    case missingWearableData
+    case missingNutritionData
+    case missingJournalData
+    case missingReflectionData
+}
+
+struct ArgoCoachAction: Identifiable, Sendable {
+    let id: String
+    let title: String
+    let body: String
+    let primaryLabel: String
+    let kind: Kind
+
+    enum Kind: String, Sendable {
+        case logMeal
+        case planWorkout
+        case reflectWorkout
+        case adjustTraining
+        case recoveryHabit
+    }
+}
+
+extension Notification.Name {
+    static let argoDailyContextDidChange = Notification.Name("argoDailyContextDidChange")
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run the same `xcodebuild test` command from Step 2.
+
+Expected: PASS for `ArgoDailyContextTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift" "DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyContextTests.swift"
+git commit -m "Add Argo daily context models"
+```
+
+---
+
+### Task 2: Add Event Mapping
+
+**Files:**
+- Create: `DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift`
+- Test: `DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyEventMapperTests.swift`
+
+- [ ] **Step 1: Write failing mapper tests**
+
+Add:
+
+```swift
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoDailyEventMapperTests {
+    @Test func mapsMealsIntoReviewableMealEventsWhenConfidenceIsLow() {
+        let createdAt = Date(timeIntervalSince1970: 3_000)
+        let meal = Meal(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000101")!,
+            userId: UUID(),
+            date: createdAt,
+            mealType: "lunch",
+            photoStoragePath: nil,
+            photoUrl: nil,
+            foodDescription: "Chicken bowl",
+            estimatedCalories: 740,
+            estimatedProteinG: 48,
+            estimatedCarbsG: 82,
+            estimatedFatG: 24,
+            estimatedFiberG: nil,
+            aiConfidence: 0.52,
+            userCalories: nil,
+            userProteinG: nil,
+            userCarbsG: nil,
+            userFatG: nil,
+            userNotes: nil,
+            createdAt: createdAt,
+            updatedAt: nil
+        )
+
+        let event = ArgoDailyEventMapper.makeMealEvent(meal)
+
+        #expect(event.id == "meal-00000000-0000-0000-0000-000000000101")
+        #expect(event.source == .meal)
+        #expect(event.type == .mealLogged)
+        #expect(event.title == "Lunch logged")
+        #expect(event.summary.contains("740 cal"))
+        #expect(event.summary.contains("48g protein"))
+        #expect(event.confidence == 0.52)
+        #expect(event.requiresReview)
+    }
+
+    @Test func mapsTrainingPlansIntoUpcomingPlanEvents() {
+        let date = Date(timeIntervalSince1970: 86_400)
+        let plan = TrainingPlan(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000202")!,
+            userId: UUID(),
+            date: date,
+            sequence: 0,
+            trainingType: "strength_training",
+            startTime: "17:30:00",
+            intensity: "moderate",
+            durationMinutes: 60,
+            notes: "Lower body",
+            createdAt: nil,
+            updatedAt: nil
+        )
+
+        let event = ArgoDailyEventMapper.makeTrainingPlanEvent(plan, now: Date(timeIntervalSince1970: 0))
+
+        #expect(event.id == "plan-00000000-0000-0000-0000-000000000202")
+        #expect(event.source == .trainingPlan)
+        #expect(event.type == .workoutPlanned)
+        #expect(event.title == "Upcoming Strength Training")
+        #expect(event.summary.contains("60 min"))
+        #expect(event.summary.contains("Moderate"))
+        #expect(event.isUpcoming)
+    }
+}
+```
+
+- [ ] **Step 2: Run mapper tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO -only-testing:"Your Daily DoseTests/ArgoDailyEventMapperTests"
+```
+
+Expected: FAIL with `Cannot find 'ArgoDailyEventMapper' in scope`.
+
+- [ ] **Step 3: Add mapper implementation**
+
+Create `ArgoDailyEventMapper.swift`:
+
+```swift
+import Foundation
+
+enum ArgoDailyEventMapper {
+    static func makeEvents(
+        dailyEntry: DailyEntry?,
+        nutrition: DailyNutritionSummary?,
+        journalEntries: [JournalEntry],
+        workoutReflections: [WorkoutReflection],
+        plannedWorkouts: [TrainingPlan],
+        healthKitWorkouts: [HKWorkoutSummary],
+        whoop: WhoopDailyData?,
+        now: Date = Date()
+    ) -> [ArgoDailyEvent] {
+        var events: [ArgoDailyEvent] = []
+        events.append(contentsOf: nutrition?.meals.map(makeMealEvent) ?? [])
+        events.append(contentsOf: journalEntries.map(makeJournalEvent))
+        events.append(contentsOf: workoutReflections.map(makeWorkoutReflectionEvent))
+        events.append(contentsOf: plannedWorkouts.map { makeTrainingPlanEvent($0, now: now) })
+        events.append(contentsOf: healthKitWorkouts.map(makeHealthKitWorkoutEvent))
+        events.append(contentsOf: makeWhoopEvents(whoop))
+
+        if let completedAt = dailyEntry?.morningCompletedAt {
+            events.append(makeCheckInEvent(id: "morning-check-in", title: "Morning check-in", timestamp: completedAt))
+        }
+
+        if let completedAt = dailyEntry?.eveningCompletedAt {
+            events.append(makeCheckInEvent(id: "evening-check-in", title: "Evening reflection", timestamp: completedAt))
+        }
+
+        return ArgoDailyEvent.sortedRecentFirst(events)
+    }
+
+    static func makeMealEvent(_ meal: Meal) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: "meal-\(meal.id.uuidString)",
+            source: .meal,
+            type: .mealLogged,
+            timestamp: meal.createdAt ?? meal.date,
+            title: "\(meal.mealTypeDisplayName) logged",
+            summary: "\(meal.calories) cal · \(Int(meal.proteinG))g protein",
+            payload: [
+                "meal_type": AnyCodable(meal.mealType),
+                "calories": AnyCodable(meal.calories),
+                "protein_g": AnyCodable(meal.proteinG)
+            ],
+            confidence: meal.aiConfidence,
+            requiresReview: (meal.aiConfidence ?? 1.0) < 0.65,
+            sourceRecordId: meal.id.uuidString,
+            isUpcoming: false
+        )
+    }
+
+    static func makeJournalEvent(_ entry: JournalEntry) -> ArgoDailyEvent {
+        let isCheckIn = entry.tags?.contains("check-in") == true
+        return ArgoDailyEvent(
+            id: "journal-\(entry.id.uuidString)",
+            source: .journal,
+            type: isCheckIn ? .checkInLogged : .noteLogged,
+            timestamp: entry.createdAt,
+            title: entry.displayTitle,
+            summary: entry.contentPreview,
+            payload: [
+                "mood": AnyCodable(entry.mood ?? 0),
+                "energy": AnyCodable(entry.energy ?? 0)
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: entry.id.uuidString,
+            isUpcoming: false
+        )
+    }
+
+    static func makeWorkoutReflectionEvent(_ reflection: WorkoutReflection) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: "reflection-\(reflection.id.uuidString)",
+            source: .workoutReflection,
+            type: .workoutReflected,
+            timestamp: reflection.createdAt ?? reflection.date,
+            title: "\(reflection.activityType.displayName) reflected",
+            summary: reflection.formattedDuration ?? "Workout reflection saved",
+            payload: [
+                "training_feeling": AnyCodable(reflection.trainingFeeling ?? 0),
+                "energy_level": AnyCodable(reflection.energyLevel ?? 0)
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: reflection.id.uuidString,
+            isUpcoming: false
+        )
+    }
+
+    static func makeTrainingPlanEvent(_ plan: TrainingPlan, now: Date = Date()) -> ArgoDailyEvent {
+        let eventDate = dateForPlan(plan)
+        let upcoming = eventDate.map { $0 > now } ?? true
+        let summary = [plan.formattedDuration, plan.intensityLevel.displayName].compactMap { $0 }.joined(separator: " · ")
+
+        return ArgoDailyEvent(
+            id: "plan-\(plan.id.uuidString)",
+            source: .trainingPlan,
+            type: .workoutPlanned,
+            timestamp: eventDate,
+            title: upcoming ? "Upcoming \(plan.activityType.displayName)" : plan.activityType.displayName,
+            summary: summary.isEmpty ? "Planned workout" : summary,
+            payload: [
+                "training_type": AnyCodable(plan.trainingType ?? ""),
+                "intensity": AnyCodable(plan.intensity ?? "")
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: plan.id.uuidString,
+            isUpcoming: upcoming
+        )
+    }
+
+    static func makeHealthKitWorkoutEvent(_ workout: HKWorkoutSummary) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: "healthkit-\(workout.id)",
+            source: .healthKit,
+            type: .workoutCompleted,
+            timestamp: workout.endDate,
+            title: "\(workout.activityName) completed",
+            summary: "\(workout.durationMinutes) min · \(workout.totalCalories) cal",
+            payload: [
+                "duration_minutes": AnyCodable(workout.durationMinutes),
+                "calories": AnyCodable(workout.totalCalories)
+            ],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: workout.id,
+            isUpcoming: false
+        )
+    }
+
+    static func makeWhoopEvents(_ whoop: WhoopDailyData?) -> [ArgoDailyEvent] {
+        guard let whoop else { return [] }
+        var events: [ArgoDailyEvent] = []
+
+        if let recovery = whoop.recoveryScore {
+            events.append(ArgoDailyEvent(
+                id: "whoop-recovery",
+                source: .whoop,
+                type: .wearableRecovery,
+                timestamp: whoop.fetchedAt ?? whoop.date,
+                title: "Recovery updated",
+                summary: "\(Int(recovery.rounded()))% recovery",
+                payload: ["recovery_score": AnyCodable(recovery)],
+                confidence: nil,
+                requiresReview: false,
+                sourceRecordId: whoop.id?.uuidString,
+                isUpcoming: false
+            ))
+        }
+
+        if let strain = whoop.strainScore {
+            events.append(ArgoDailyEvent(
+                id: "whoop-strain",
+                source: .whoop,
+                type: .wearableStrain,
+                timestamp: whoop.fetchedAt ?? whoop.date,
+                title: "Strain updated",
+                summary: String(format: "%.1f strain", strain),
+                payload: ["strain_score": AnyCodable(strain)],
+                confidence: nil,
+                requiresReview: false,
+                sourceRecordId: whoop.id?.uuidString,
+                isUpcoming: false
+            ))
+        }
+
+        return events
+    }
+
+    static func makeCheckInEvent(id: String, title: String, timestamp: Date) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: id,
+            source: .manual,
+            type: .checkInLogged,
+            timestamp: timestamp,
+            title: title,
+            summary: "Completed",
+            payload: [:],
+            confidence: nil,
+            requiresReview: false,
+            sourceRecordId: nil,
+            isUpcoming: false
+        )
+    }
+
+    private static func dateForPlan(_ plan: TrainingPlan) -> Date? {
+        guard let startTime = plan.startTime else { return plan.date }
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let combined = "\(dateFormatter.string(from: plan.date)) \(startTime)"
+        let combinedFormatter = DateFormatter()
+        combinedFormatter.dateFormat = startTime.count == 5 ? "yyyy-MM-dd HH:mm" : "yyyy-MM-dd HH:mm:ss"
+        return combinedFormatter.date(from: combined) ?? plan.date
+    }
+}
+```
+
+- [ ] **Step 4: Run mapper tests to verify they pass**
+
+Run the same `xcodebuild test` command from Step 2.
+
+Expected: PASS for `ArgoDailyEventMapperTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift" "DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailyEventMapperTests.swift"
+git commit -m "Add Argo daily event mapping"
+```
+
+---
+
+### Task 3: Add Derived Signal Evaluation
+
+**Files:**
+- Create: `DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailySignalsEvaluator.swift`
+- Test: `DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailySignalsEvaluatorTests.swift`
+
+- [ ] **Step 1: Write failing signal tests**
+
+Add:
+
+```swift
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoDailySignalsEvaluatorTests {
+    @Test func missingDataProducesMissingContextAndLogMealAction() {
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: Date(timeIntervalSince1970: 4_000),
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            sourceFailures: []
+        )
+
+        #expect(signals.recoveryStatus == .unknown)
+        #expect(signals.fuelStatus == .notStarted)
+        #expect(signals.trainingLoadStatus == .open)
+        #expect(signals.missingContext.contains(.noMeals))
+        #expect(signals.missingContext.contains(.noPlan))
+        #expect(signals.missingContext.contains(.missingWearableData))
+        #expect(signals.nextAction?.kind == .logMeal)
+    }
+
+    @Test func lowRecoveryWithPlanRecommendsAdjustTraining() {
+        let date = Date(timeIntervalSince1970: 4_000)
+        let whoop = WhoopDailyData(
+            id: nil,
+            userId: nil,
+            date: date,
+            recoveryScore: 32,
+            recoveryZone: .red,
+            sleepPerformance: nil,
+            sleepDurationMinutes: nil,
+            sleepEfficiency: nil,
+            sleepStages: nil,
+            respiratoryRate: nil,
+            skinTempDelta: nil,
+            hrv: nil,
+            restingHr: nil,
+            strainScore: nil,
+            fetchedAt: date
+        )
+        let plan = TrainingPlan(
+            id: UUID(),
+            userId: UUID(),
+            date: date,
+            sequence: 0,
+            trainingType: "running",
+            startTime: "18:00:00",
+            intensity: "hard",
+            durationMinutes: 45,
+            notes: nil,
+            createdAt: nil,
+            updatedAt: nil
+        )
+
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: nil,
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [plan],
+            healthKitWorkouts: [],
+            whoop: whoop,
+            sourceFailures: []
+        )
+
+        #expect(signals.recoveryStatus == .low)
+        #expect(signals.trainingLoadStatus == .planned)
+        #expect(signals.nextAction?.kind == .adjustTraining)
+    }
+}
+```
+
+- [ ] **Step 2: Run signal tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO -only-testing:"Your Daily DoseTests/ArgoDailySignalsEvaluatorTests"
+```
+
+Expected: FAIL with `Cannot find 'ArgoDailySignalsEvaluator' in scope`.
+
+- [ ] **Step 3: Add signal evaluator implementation**
+
+Create `ArgoDailySignalsEvaluator.swift`:
+
+```swift
+import Foundation
+
+enum ArgoDailySignalsEvaluator {
+    static func evaluate(
+        date: Date,
+        dailyEntry: DailyEntry?,
+        nutrition: DailyNutritionSummary?,
+        journalEntries: [JournalEntry],
+        workoutReflections: [WorkoutReflection],
+        plannedWorkouts: [TrainingPlan],
+        healthKitWorkouts: [HKWorkoutSummary],
+        whoop: WhoopDailyData?,
+        sourceFailures: Set<MissingContextFlag>
+    ) -> ArgoDailySignals {
+        let recovery = recoveryStatus(from: whoop)
+        let fuel = fuelStatus(from: nutrition)
+        let load = trainingLoadStatus(plans: plannedWorkouts, workouts: healthKitWorkouts, whoop: whoop)
+        let missing = missingContext(
+            dailyEntry: dailyEntry,
+            nutrition: nutrition,
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            workoutReflections: workoutReflections,
+            whoop: whoop,
+            sourceFailures: sourceFailures
+        )
+        let action = nextAction(recovery: recovery, fuel: fuel, load: load, missing: missing)
+
+        return ArgoDailySignals(
+            recoveryStatus: recovery,
+            fuelStatus: fuel,
+            trainingLoadStatus: load,
+            missingContext: missing,
+            nextAction: action,
+            summaryText: summaryText(recovery: recovery, fuel: fuel, load: load)
+        )
+    }
+
+    private static func recoveryStatus(from whoop: WhoopDailyData?) -> RecoveryStatus {
+        guard let score = whoop?.recoveryScore else { return .unknown }
+        if score < 34 { return .low }
+        if score < 67 { return .moderate }
+        return .ready
+    }
+
+    private static func fuelStatus(from nutrition: DailyNutritionSummary?) -> FuelStatus {
+        guard let nutrition else { return .notStarted }
+        if nutrition.mealCount == 0 { return .notStarted }
+        if nutrition.totalCalories < 1_200 || nutrition.totalProteinG < 60 { return .underFueled }
+        return .onTrack
+    }
+
+    private static func trainingLoadStatus(plans: [TrainingPlan], workouts: [HKWorkoutSummary], whoop: WhoopDailyData?) -> TrainingLoadStatus {
+        if let strain = whoop?.strainScore, strain >= 14 { return .high }
+        if !workouts.isEmpty { return .completed }
+        if !plans.isEmpty { return .planned }
+        return .open
+    }
+
+    private static func missingContext(
+        dailyEntry: DailyEntry?,
+        nutrition: DailyNutritionSummary?,
+        plannedWorkouts: [TrainingPlan],
+        healthKitWorkouts: [HKWorkoutSummary],
+        workoutReflections: [WorkoutReflection],
+        whoop: WhoopDailyData?,
+        sourceFailures: Set<MissingContextFlag>
+    ) -> Set<MissingContextFlag> {
+        var flags = sourceFailures
+
+        if nutrition == nil || nutrition?.mealCount == 0 {
+            flags.insert(.noMeals)
+        }
+
+        if plannedWorkouts.isEmpty {
+            flags.insert(.noPlan)
+        }
+
+        if dailyEntry?.isMorningComplete != true {
+            flags.insert(.noMorningCheckIn)
+        }
+
+        if !healthKitWorkouts.isEmpty && workoutReflections.isEmpty {
+            flags.insert(.missingWorkoutReflection)
+        }
+
+        if whoop == nil {
+            flags.insert(.missingWearableData)
+        }
+
+        return flags
+    }
+
+    private static func nextAction(
+        recovery: RecoveryStatus,
+        fuel: FuelStatus,
+        load: TrainingLoadStatus,
+        missing: Set<MissingContextFlag>
+    ) -> ArgoCoachAction? {
+        if fuel == .notStarted || missing.contains(.noMeals) {
+            return ArgoCoachAction(
+                id: "log-first-meal",
+                title: "Log your first meal.",
+                body: "Food context helps Argo judge recovery, training load, and evening choices.",
+                primaryLabel: "Log meal",
+                kind: .logMeal
+            )
+        }
+
+        if recovery == .low && (load == .planned || load == .high) {
+            return ArgoCoachAction(
+                id: "adjust-training",
+                title: "Keep training controlled.",
+                body: "Recovery is low, so reduce intensity or move the hard work to a better day.",
+                primaryLabel: "Adjust plan",
+                kind: .adjustTraining
+            )
+        }
+
+        if missing.contains(.missingWorkoutReflection) {
+            return ArgoCoachAction(
+                id: "reflect-workout",
+                title: "Reflect on the completed workout.",
+                body: "A short reflection helps Argo connect wearable load to how the session felt.",
+                primaryLabel: "Reflect",
+                kind: .reflectWorkout
+            )
+        }
+
+        if missing.contains(.noPlan) {
+            return ArgoCoachAction(
+                id: "plan-workout",
+                title: "Set today's training anchor.",
+                body: "Add the key session time so Argo can structure food and recovery around it.",
+                primaryLabel: "Plan",
+                kind: .planWorkout
+            )
+        }
+
+        return ArgoCoachAction(
+            id: "recovery-habit",
+            title: "Protect recovery tonight.",
+            body: "Keep a small block for family, reading, or relaxed downtime before sleep.",
+            primaryLabel: "Add habit",
+            kind: .recoveryHabit
+        )
+    }
+
+    private static func summaryText(recovery: RecoveryStatus, fuel: FuelStatus, load: TrainingLoadStatus) -> String {
+        "Recovery is \(recovery.rawValue), fuel is \(fuel.rawValue), and training load is \(load.rawValue)."
+    }
+}
+```
+
+- [ ] **Step 4: Run signal tests to verify they pass**
+
+Run the same `xcodebuild test` command from Step 2.
+
+Expected: PASS for `ArgoDailySignalsEvaluatorTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailySignalsEvaluator.swift" "DailyRitualSwiftiOS/Your Daily DoseTests/ArgoDailySignalsEvaluatorTests.swift"
+git commit -m "Add Argo daily signal evaluation"
+```
+
+---
+
+### Task 4: Add Client Context Provider
+
+**Files:**
+- Create: `DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift`
+- Test: `DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift`
+
+- [ ] **Step 1: Write failing provider tests**
+
+Add:
+
+```swift
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+@MainActor
+struct ClientDailyContextServiceTests {
+    @Test func returnsPartialContextWhenMealsFail() async {
+        let date = Date(timeIntervalSince1970: 5_000)
+        let service = ClientDailyContextService(
+            mealsService: FailingMealsService(),
+            journalService: EmptyJournalEntriesService(),
+            workoutReflectionsService: EmptyWorkoutReflectionsService(),
+            dailyEntriesService: EmptyDailyEntriesService(),
+            whoopDataProvider: { nil },
+            healthKitWorkoutsProvider: { [] }
+        )
+
+        let context = await service.context(for: date)
+
+        #expect(context.date == date)
+        #expect(context.nutrition == nil)
+        #expect(context.derived.missingContext.contains(.missingNutritionData))
+        #expect(context.derived.missingContext.contains(.noMeals))
+    }
+}
+
+private enum TestError: Error {
+    case failed
+}
+
+private struct FailingMealsService: MealsServiceProtocol {
+    func uploadMeal(photoData: Data, mimeType: String, mealType: String, date: String) async throws -> Meal { throw TestError.failed }
+    func getMeals(date: String) async throws -> [Meal] { throw TestError.failed }
+    func updateMeal(id: UUID, updates: [String: Any]) async throws -> Meal { throw TestError.failed }
+    func deleteMeal(id: UUID) async throws {}
+    func getDailyNutrition(date: String) async throws -> DailyNutritionSummary { throw TestError.failed }
+}
+
+private final class EmptyJournalEntriesService: JournalEntriesServiceProtocol, @unchecked Sendable {
+    func fetchEntries(page: Int, limit: Int) async throws -> (entries: [JournalEntry], hasNext: Bool) { ([], false) }
+    func fetchEntry(id: UUID) async throws -> JournalEntry { throw TestError.failed }
+    func createEntry(title: String?, content: String, mood: Int?, energy: Int?, tags: [String]?) async throws -> JournalEntry { throw TestError.failed }
+    func updateEntry(id: UUID, title: String?, content: String?, mood: Int?, energy: Int?, tags: [String]?) async throws -> JournalEntry { throw TestError.failed }
+    func deleteEntry(id: UUID) async throws {}
+    func fetchEntriesForDate(_ date: Date) async throws -> [JournalEntry] { [] }
+}
+
+private struct EmptyWorkoutReflectionsService: WorkoutReflectionsServiceProtocol {
+    func create(_ reflection: WorkoutReflection) async throws -> WorkoutReflection { reflection }
+    func list(date: Date?) async throws -> [WorkoutReflection] { [] }
+    func get(id: UUID) async throws -> WorkoutReflection? { nil }
+    func update(_ reflection: WorkoutReflection) async throws -> WorkoutReflection { reflection }
+    func delete(id: UUID) async throws {}
+    func getStats(days: Int) async throws -> WorkoutReflectionStats {
+        WorkoutReflectionStats(periodDays: days, totalWorkouts: 0, avgTrainingFeeling: 0, avgEnergyLevel: 0, avgFocusLevel: 0, totalMinutes: 0, workoutTypeDistribution: [:], workoutsPerWeek: 0)
+    }
+}
+
+private struct EmptyDailyEntriesService: DailyEntriesServiceProtocol {
+    func getEntry(for date: Date) async throws -> DailyEntry? { nil }
+    func getTrainingPlans(for date: Date) async throws -> [TrainingPlan] { [] }
+    func getQuote(for date: Date) async throws -> Quote? { nil }
+    func completeMorning(for entry: DailyEntry) async throws -> DailyEntry { entry }
+    func completeEvening(for entry: DailyEntry) async throws -> DailyEntry { entry }
+    func getEntriesBatch(for dates: [Date]) async throws -> [String: DailyEntry] { [:] }
+    func getEntriesWithPlansBatch(for dates: [Date]) async throws -> (entries: [String: DailyEntry], plans: [String: [TrainingPlan]]) { ([:], [:]) }
+    @MainActor func prefetchEntriesAround(date: Date, range: Int) {}
+}
+```
+
+- [ ] **Step 2: Run provider tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO -only-testing:"Your Daily DoseTests/ClientDailyContextServiceTests"
+```
+
+Expected: FAIL with `Cannot find 'ClientDailyContextService' in scope`.
+
+- [ ] **Step 3: Add provider implementation**
+
+Create `ClientDailyContextService.swift`:
+
+```swift
+import Foundation
+
+protocol DailyContextProviding: AnyObject {
+    @MainActor func context(for date: Date) async -> ArgoDailyContext
+    @MainActor func refresh(for date: Date) async -> ArgoDailyContext
+}
+
+@MainActor
+final class ClientDailyContextService: DailyContextProviding {
+    private let mealsService: MealsServiceProtocol
+    private let journalService: JournalEntriesServiceProtocol
+    private let workoutReflectionsService: WorkoutReflectionsServiceProtocol
+    private let dailyEntriesService: DailyEntriesServiceProtocol
+    private let whoopDataProvider: () -> WhoopDailyData?
+    private let healthKitWorkoutsProvider: () -> [HKWorkoutSummary]
+
+    init(
+        mealsService: MealsServiceProtocol = MealsService(),
+        journalService: JournalEntriesServiceProtocol = JournalEntriesService(),
+        workoutReflectionsService: WorkoutReflectionsServiceProtocol = WorkoutReflectionsService(),
+        dailyEntriesService: DailyEntriesServiceProtocol = DailyEntriesService(),
+        whoopDataProvider: @escaping () -> WhoopDailyData? = { WhoopService.shared.dailyData },
+        healthKitWorkoutsProvider: @escaping () -> [HKWorkoutSummary] = { HealthKitService.shared.todayWorkouts }
+    ) {
+        self.mealsService = mealsService
+        self.journalService = journalService
+        self.workoutReflectionsService = workoutReflectionsService
+        self.dailyEntriesService = dailyEntriesService
+        self.whoopDataProvider = whoopDataProvider
+        self.healthKitWorkoutsProvider = healthKitWorkoutsProvider
+    }
+
+    func context(for date: Date) async -> ArgoDailyContext {
+        await refresh(for: date)
+    }
+
+    func refresh(for date: Date) async -> ArgoDailyContext {
+        var sourceFailures: Set<MissingContextFlag> = []
+
+        let dailyEntry: DailyEntry?
+        do {
+            dailyEntry = try await dailyEntriesService.getEntry(for: date)
+        } catch {
+            sourceFailures.insert(.noMorningCheckIn)
+            dailyEntry = nil
+        }
+
+        let plans: [TrainingPlan]
+        do {
+            plans = try await dailyEntriesService.getTrainingPlans(for: date)
+        } catch {
+            sourceFailures.insert(.noPlan)
+            plans = []
+        }
+
+        let nutrition: DailyNutritionSummary?
+        do {
+            nutrition = try await mealsService.getDailyNutrition(date: dateString(date))
+        } catch {
+            sourceFailures.insert(.missingNutritionData)
+            nutrition = nil
+        }
+
+        let journalEntries: [JournalEntry]
+        do {
+            journalEntries = try await journalService.fetchEntriesForDate(date)
+        } catch {
+            sourceFailures.insert(.missingJournalData)
+            journalEntries = []
+        }
+
+        let workoutReflections: [WorkoutReflection]
+        do {
+            workoutReflections = try await workoutReflectionsService.list(date: date)
+        } catch {
+            sourceFailures.insert(.missingReflectionData)
+            workoutReflections = []
+        }
+
+        let whoop = whoopDataProvider()
+        let healthKitWorkouts = healthKitWorkoutsProvider()
+        let signals = ArgoDailySignalsEvaluator.evaluate(
+            date: date,
+            dailyEntry: dailyEntry,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plans,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop,
+            sourceFailures: sourceFailures
+        )
+        let events = ArgoDailyEventMapper.makeEvents(
+            dailyEntry: dailyEntry,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plans,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop
+        )
+
+        return ArgoDailyContext(
+            date: date,
+            dailyEntry: dailyEntry,
+            events: events,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plans,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop,
+            derived: signals
+        )
+    }
+
+    private func dateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}
+```
+
+- [ ] **Step 4: Run provider tests to verify they pass**
+
+Run the same `xcodebuild test` command from Step 2.
+
+Expected: PASS for `ClientDailyContextServiceTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift" "DailyRitualSwiftiOS/Your Daily DoseTests/ClientDailyContextServiceTests.swift"
+git commit -m "Add client daily context service"
+```
+
+---
+
+### Task 5: Wire Today To Daily Context
+
+**Files:**
+- Modify: `DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift`
+- Modify: `DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift`
+
+- [ ] **Step 1: Add event adapter test**
+
+Append to `TodayTimelineItemTests.swift`:
+
+```swift
+@Test func adaptsArgoEventIntoTimelineItem() {
+    let timestamp = Date(timeIntervalSince1970: 6_000)
+    let event = ArgoDailyEvent(
+        id: "meal-1",
+        source: .meal,
+        type: .mealLogged,
+        timestamp: timestamp,
+        title: "Lunch logged",
+        summary: "740 cal · 48g protein",
+        payload: [:],
+        confidence: 0.8,
+        requiresReview: false,
+        sourceRecordId: "meal-1",
+        isUpcoming: false
+    )
+
+    let item = TodayTimelineItem(event: event)
+
+    #expect(item.id == "meal-1")
+    #expect(item.kind == .meal)
+    #expect(item.title == "Lunch logged")
+    #expect(item.subtitle == "740 cal · 48g protein")
+    #expect(item.timestamp == timestamp)
+}
+```
+
+- [ ] **Step 2: Run Today timeline tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO -only-testing:"Your Daily DoseTests/TodayTimelineItemTests"
+```
+
+Expected: FAIL with `No exact matches in call to initializer` for `TodayTimelineItem(event:)`.
+
+- [ ] **Step 3: Add timeline adapter**
+
+Add to `TodayTimelineItem.swift`:
+
+```swift
+extension TodayTimelineItem {
+    init(event: ArgoDailyEvent) {
+        self.init(
+            id: event.id,
+            kind: TodayTimelineItem.kind(for: event),
+            title: event.title,
+            subtitle: event.summary,
+            timestamp: event.timestamp,
+            displayTime: event.timestamp.map(Self.formattedTime) ?? "Planned",
+            isUpcoming: event.isUpcoming,
+            accent: event.requiresReview ? .attention : (event.isUpcoming ? .muted : .standard)
+        )
+    }
+
+    private static func kind(for event: ArgoDailyEvent) -> Kind {
+        switch event.type {
+        case .mealLogged:
+            return .meal
+        case .workoutPlanned, .workoutCompleted, .workoutReflected:
+            return .workout
+        case .checkInLogged:
+            return .checkIn
+        case .coachRecommendation:
+            return .coach
+        case .noteLogged, .wearableRecovery, .wearableSleep, .wearableStrain:
+            return .note
+        }
+    }
+
+    private static func formattedTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        return formatter.string(from: date)
+    }
+}
+```
+
+- [ ] **Step 4: Run Today timeline tests to verify they pass**
+
+Run the same `xcodebuild test` command from Step 2.
+
+Expected: PASS for `TodayTimelineItemTests`.
+
+- [ ] **Step 5: Update `TodayView` to load context**
+
+Modify `TodayView`:
+
+```swift
+@State private var dailyContext: ArgoDailyContext?
+private let contextService: DailyContextProviding
+
+init(
+    onLogTap: @escaping () -> Void = {},
+    onCoachTap: @escaping () -> Void = {},
+    contextService: DailyContextProviding = ClientDailyContextService()
+) {
+    self.onLogTap = onLogTap
+    self.onCoachTap = onCoachTap
+    self.contextService = contextService
+}
+```
+
+Replace the computed values for brief and timeline with context-backed values:
+
+```swift
+private var timelineItems: [TodayTimelineItem] {
+    TodayTimelineItem.sortedRecentFirst((dailyContext?.events ?? []).map(TodayTimelineItem.init(event:)))
+}
+
+private var roundedRecoveryScore: Int? {
+    dailyContext?.whoop?.recoveryScore.map { Int($0.rounded()) }
+}
+
+private var sleepSummaryText: String {
+    guard let data = dailyContext?.whoop else { return "--" }
+    if let minutes = data.sleepDurationMinutes { return formatMinutes(minutes) }
+    if let performance = data.sleepPerformance { return "\(Int(performance.rounded()))%" }
+    return "--"
+}
+
+private var fuelSummaryText: String {
+    guard let nutrition = dailyContext?.nutrition else { return "No meals" }
+    return nutrition.mealCount == 0 ? "No meals" : "\(nutrition.totalCalories) cal"
+}
+
+private var loadSummaryText: String {
+    switch dailyContext?.derived.trainingLoadStatus {
+    case .high:
+        return "High"
+    case .completed:
+        return "Complete"
+    case .planned:
+        return "Planned"
+    case .open:
+        return "Open"
+    case .unknown, .none:
+        return "--"
+    }
+}
+
+private var planSummaryText: String {
+    let plans = dailyContext?.plannedWorkouts ?? []
+    guard let firstPlan = plans.first else {
+        return "No training plan yet. Add the key session, meals, and recovery block for the day."
+    }
+    let time = firstPlan.formattedStartTime ?? "Planned"
+    return "\(firstPlan.activityType.displayName) at \(time)."
+}
+
+private var nextActionText: String {
+    dailyContext?.derived.nextAction?.title ?? "Build today's context."
+}
+
+private var nextActionRationale: String {
+    dailyContext?.derived.nextAction?.body ?? "Log meals, training, and reflections so Argo can coach from useful data."
+}
+```
+
+Add a loader and call it from `.task`, `.refreshable`, date changes, and `.onReceive(.argoDailyContextDidChange)`:
+
+```swift
+private func loadDailyContext(for date: Date) async {
+    dailyContext = await contextService.refresh(for: date)
+}
+```
+
+- [ ] **Step 6: Run a full build/test command**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS on a configured simulator runtime. If local Xcode reports missing simulator runtimes, run:
+
+```bash
+git diff --check -- "DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift" "DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift" "DailyRitualSwiftiOS/Your Daily DoseTests/TodayTimelineItemTests.swift"
+```
+
+Expected: no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "DailyRitualSwiftiOS/Your Daily Dose/Views/Today/TodayTimelineItem.swift" "DailyRitualSwiftiOS/Your Daily Dose/Views/TodayView.swift" "DailyRitualSwiftiOS/Your Daily DoseTests/TodayTimelineItemTests.swift"
+git commit -m "Wire Today to Argo daily context"
+```
+
+---
+
+### Task 6: Wire Coach To Daily Context
+
+**Files:**
+- Modify: `DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift`
+
+- [ ] **Step 1: Replace static recommendations with context-driven state**
+
+Modify `CoachView` to accept a provider:
+
+```swift
+struct CoachView: View {
+    private let contextService: DailyContextProviding
+    @State private var context: ArgoDailyContext?
+
+    init(contextService: DailyContextProviding = ClientDailyContextService()) {
+        self.contextService = contextService
+    }
+
+    private var recommendations: [ArgoCoachAction] {
+        var actions: [ArgoCoachAction] = []
+        if let action = context?.derived.nextAction {
+            actions.append(action)
+        }
+
+        if context?.derived.missingContext.contains(.noMeals) == true {
+            actions.append(ArgoCoachAction(
+                id: "coach-log-meal",
+                title: "Add food context.",
+                body: "A quick meal photo or text note helps Argo estimate fuel for the rest of the day.",
+                primaryLabel: "Log meal",
+                kind: .logMeal
+            ))
+        }
+
+        if context?.derived.missingContext.contains(.missingWearableData) == true {
+            actions.append(ArgoCoachAction(
+                id: "coach-connect-wearable",
+                title: "Wearable data is missing.",
+                body: "Recovery and strain recommendations improve when Whoop, Garmin, or Apple Health data is current.",
+                primaryLabel: "Review",
+                kind: .recoveryHabit
+            ))
+        }
+
+        return Array(actions.prefix(3))
+    }
+}
+```
+
+Replace the header subcopy with context summary when available:
+
+```swift
+Text(context?.derived.summaryText ?? "Ask about training, food, recovery, and how to structure the week.")
+```
+
+Update the card renderer to accept `ArgoCoachAction`:
+
+```swift
+private func recommendationCard(_ recommendation: ArgoCoachAction) -> some View {
+    VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+            Text(recommendation.title)
+                .font(DesignSystem.Typography.headlineSmall)
+                .foregroundColor(DesignSystem.Colors.primaryText)
+
+            Text(recommendation.body)
+                .font(DesignSystem.Typography.bodyMedium)
+                .foregroundColor(DesignSystem.Colors.secondaryText)
+        }
+
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            actionButton(recommendation.primaryLabel, filled: true)
+            actionButton("Edit", filled: false)
+            actionButton("Skip", filled: false)
+        }
+    }
+    .padding(DesignSystem.Spacing.md)
+    .background(DesignSystem.Colors.cardBackground)
+    .overlay(
+        RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card)
+            .stroke(DesignSystem.Colors.border, lineWidth: 1)
+    )
+    .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card))
+}
+```
+
+Add loading:
+
+```swift
+private func loadContext() async {
+    context = await contextService.refresh(for: Date())
+}
+```
+
+Call it in `.task` and `.onReceive(NotificationCenter.default.publisher(for: .argoDailyContextDidChange))`.
+
+- [ ] **Step 2: Run full build/test command**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS on a configured simulator runtime. If local Xcode reports missing simulator runtimes, run:
+
+```bash
+git diff --check -- "DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift"
+git commit -m "Wire Coach to Argo daily context"
+```
+
+---
+
+### Task 7: Refresh Context After Log Flows
+
+**Files:**
+- Modify: `DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift`
+
+- [ ] **Step 1: Post refresh notification on log sheet dismissal**
+
+Update log sheets in `MainTabView`:
+
+```swift
+.sheet(isPresented: $showingMealLog, onDismiss: notifyDailyContextChanged) {
+    MealLogView(date: Date())
+}
+.sheet(isPresented: $showingVoiceEntry, onDismiss: notifyDailyContextChanged) {
+    QuickEntryView(date: Date())
+}
+.sheet(isPresented: $showingWorkoutReflection, onDismiss: notifyDailyContextChanged) {
+    WorkoutReflectionView(linkedPlan: nil, healthKitData: nil)
+}
+.sheet(isPresented: $showingCheckIn, onDismiss: notifyDailyContextChanged) {
+    QuickEntryView(date: Date())
+}
+```
+
+Add helper:
+
+```swift
+private func notifyDailyContextChanged() {
+    NotificationCenter.default.post(name: .argoDailyContextDidChange, object: nil)
+}
+```
+
+- [ ] **Step 2: Run full build/test command**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS on a configured simulator runtime. If local Xcode reports missing simulator runtimes, run:
+
+```bash
+git diff --check -- "DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift"
+git commit -m "Refresh Argo context after logging"
+```
+
+---
+
+### Task 8: Final Verification
+
+**Files:**
+- Read: all files modified in Tasks 1-7
+
+- [ ] **Step 1: Run full test/build verification**
+
+Run:
+
+```bash
+xcodebuild test -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS on a configured simulator runtime. If local Xcode reports missing simulator runtimes, record the exact CoreSimulator/asset catalog failure and run the remaining checks below.
+
+- [ ] **Step 2: Run whitespace verification**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Review commits**
+
+Run:
+
+```bash
+git log --oneline -8
+```
+
+Expected: the newest commits are the task commits from this plan.
+
+- [ ] **Step 4: Check worktree status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only pre-existing unrelated dirty files remain, or a clean worktree if those were handled outside this plan.


### PR DESCRIPTION
## Summary
- Add Argo daily context models, event mapping, signal evaluation, and client aggregation over meals, journal, workouts, plans, Whoop, and HealthKit.
- Wire Today and Coach to the normalized daily context so timeline, brief, and proposed actions share one source of truth.
- Refresh context after successful logging flows and persist HealthKit workout IDs on workout reflections to avoid duplicate load/reflection prompts.

## Verification
- git diff --check
- xcodebuild build-for-testing -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination 'id=00006040-000270181A92801C' CODE_SIGNING_ALLOWED=NO

## Notes
- Full simulator test execution is still blocked locally when targeting iPhone 16 because that simulator destination is unavailable. The concrete Mac destination builds for testing but cannot execute unsigned iOS app tests.