### PR TITLE
Add actionable Argo coach proposals

### DIFF
--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoCoachProposal.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoCoachProposal.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+struct ArgoCoachProposal: Identifiable, Codable, Sendable {
+    let id: String
+    let dateKey: String
+    let action: ArgoCoachAction
+    let status: Status
+    let payload: [String: AnyCodable]
+    let createdAt: Date
+    let updatedAt: Date
+
+    enum Status: String, Codable, Sendable {
+        case pending
+        case accepted
+        case edited
+        case rejected
+        case completed
+
+        var isVisible: Bool {
+            switch self {
+            case .pending, .accepted, .edited:
+                return true
+            case .rejected, .completed:
+                return false
+            }
+        }
+
+        var displayName: String {
+            switch self {
+            case .pending:
+                return "Pending"
+            case .accepted:
+                return "Accepted"
+            case .edited:
+                return "Edited"
+            case .rejected:
+                return "Skipped"
+            case .completed:
+                return "Completed"
+            }
+        }
+    }
+
+    var isVisible: Bool {
+        status.isVisible
+    }
+
+    func updatingStatus(_ newStatus: Status, at date: Date = Date()) -> ArgoCoachProposal {
+        ArgoCoachProposal(
+            id: id,
+            dateKey: dateKey,
+            action: action,
+            status: newStatus,
+            payload: payload,
+            createdAt: createdAt,
+            updatedAt: date
+        )
+    }
+
+    static func stableID(date: Date, action: ArgoCoachAction) -> String {
+        "\(dateKey(for: date))-\(action.id)"
+    }
+
+    static func dateKey(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Calendar.current.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}
+
+enum ArgoCoachActionGenerator {
+    static func actions(for context: ArgoDailyContext) -> [ArgoCoachAction] {
+        var actions: [ArgoCoachAction] = []
+
+        func appendIfUnique(_ action: ArgoCoachAction) {
+            guard !actions.contains(where: { $0.id == action.id }) else { return }
+            actions.append(action)
+        }
+
+        if let nextAction = context.derived.nextAction {
+            appendIfUnique(nextAction)
+        }
+
+        if context.derived.missingContext.contains(.noMeals),
+           !actions.contains(where: { $0.kind == .logMeal }) {
+            appendIfUnique(
+                ArgoCoachAction(
+                    id: "coach-log-meal",
+                    title: "Add food context.",
+                    body: "A quick meal photo or text note helps Argo estimate fuel for the rest of the day.",
+                    primaryLabel: "Log meal",
+                    kind: .logMeal
+                )
+            )
+        }
+
+        if context.derived.missingContext.contains(.missingWearableData) {
+            appendIfUnique(
+                ArgoCoachAction(
+                    id: "coach-connect-wearable",
+                    title: "Wearable data is missing.",
+                    body: "Recovery and strain recommendations improve when Whoop, Garmin, or Apple Health data is current.",
+                    primaryLabel: "Review",
+                    kind: .recoveryHabit
+                )
+            )
+        }
+
+        return Array(actions.prefix(3))
+    }
+}
+
+enum ArgoCoachProposalGenerator {
+    static func makeProposals(
+        for context: ArgoDailyContext,
+        existing: [ArgoCoachProposal],
+        now: Date = Date()
+    ) -> [ArgoCoachProposal] {
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+
+        return ArgoCoachActionGenerator.actions(for: context).compactMap { action in
+            let id = ArgoCoachProposal.stableID(date: context.date, action: action)
+            if let proposal = existingByID[id] {
+                return proposal.isVisible ? proposal : nil
+            }
+
+            return ArgoCoachProposal(
+                id: id,
+                dateKey: ArgoCoachProposal.dateKey(for: context.date),
+                action: action,
+                status: .pending,
+                payload: [:],
+                createdAt: now,
+                updatedAt: now
+            )
+        }
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyContext.swift
@@ -10,6 +10,7 @@ struct ArgoDailyContext {
     let plannedWorkouts: [TrainingPlan]
     let healthKitWorkouts: [HKWorkoutSummary]
     let whoop: WhoopDailyData?
+    let coachProposals: [ArgoCoachProposal]
     let derived: ArgoDailySignals
 
     static func empty(date: Date, sourceFailures: Set<MissingContextFlag> = []) -> ArgoDailyContext {
@@ -23,6 +24,7 @@ struct ArgoDailyContext {
             plannedWorkouts: [],
             healthKitWorkouts: [],
             whoop: nil,
+            coachProposals: [],
             derived: ArgoDailySignals(
                 recoveryStatus: .unknown,
                 fuelStatus: .unknown,
@@ -132,14 +134,14 @@ enum MissingContextFlag: String, Hashable, Sendable {
     case missingReflectionData
 }
 
-struct ArgoCoachAction: Identifiable, Sendable {
+struct ArgoCoachAction: Identifiable, Codable, Sendable {
     let id: String
     let title: String
     let body: String
     let primaryLabel: String
     let kind: Kind
 
-    enum Kind: String, Sendable {
+    enum Kind: String, Codable, Sendable {
         case logMeal
         case planWorkout
         case reflectWorkout

--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoDailyEventMapper.swift
@@ -9,6 +9,7 @@ enum ArgoDailyEventMapper {
         plannedWorkouts: [TrainingPlan],
         healthKitWorkouts: [HKWorkoutSummary],
         whoop: WhoopDailyData?,
+        coachProposals: [ArgoCoachProposal] = [],
         now: Date = Date()
     ) -> [ArgoDailyEvent] {
         var events: [ArgoDailyEvent] = []
@@ -18,6 +19,7 @@ enum ArgoDailyEventMapper {
         events.append(contentsOf: plannedWorkouts.map { makeTrainingPlanEvent($0, now: now) })
         events.append(contentsOf: healthKitWorkouts.map(makeHealthKitWorkoutEvent))
         events.append(contentsOf: makeWhoopEvents(whoop))
+        events.append(contentsOf: coachProposals.filter(\.isVisible).map(makeCoachProposalEvent))
 
         if let completedAt = dailyEntry?.morningCompletedAt {
             events.append(makeCheckInEvent(id: "morning-check-in", title: "Morning check-in", timestamp: completedAt))
@@ -211,6 +213,26 @@ enum ArgoDailyEventMapper {
             requiresReview: false,
             sourceRecordId: nil,
             isUpcoming: false
+        )
+    }
+
+    static func makeCoachProposalEvent(_ proposal: ArgoCoachProposal) -> ArgoDailyEvent {
+        ArgoDailyEvent(
+            id: "coach-\(proposal.id)",
+            source: .coach,
+            type: .coachRecommendation,
+            timestamp: proposal.updatedAt,
+            title: proposal.action.title,
+            summary: "\(proposal.status.displayName): \(proposal.action.body)",
+            payload: [
+                "proposal_id": AnyCodable(proposal.id),
+                "status": AnyCodable(proposal.status.rawValue),
+                "kind": AnyCodable(proposal.action.kind.rawValue)
+            ],
+            confidence: nil,
+            requiresReview: proposal.status == .pending,
+            sourceRecordId: proposal.id,
+            isUpcoming: proposal.status != .completed
         )
     }
 

--- a/DailyRitualSwiftiOS/Your Daily Dose/Services/ArgoCoachProposalStore.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Services/ArgoCoachProposalStore.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+protocol ArgoCoachProposalStoring: AnyObject {
+    func loadProposals(for date: Date) -> [ArgoCoachProposal]
+    func upsert(_ proposal: ArgoCoachProposal)
+    @discardableResult func updateStatus(
+        proposalId: String,
+        status: ArgoCoachProposal.Status,
+        at date: Date
+    ) -> ArgoCoachProposal?
+}
+
+final class LocalArgoCoachProposalStore: ArgoCoachProposalStoring {
+    private let defaults: UserDefaults
+    private let storageKey: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = "argo_coach_proposals_v1"
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+    }
+
+    func loadProposals(for date: Date) -> [ArgoCoachProposal] {
+        let dateKey = ArgoCoachProposal.dateKey(for: date)
+        return loadAll()
+            .filter { $0.dateKey == dateKey }
+            .sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    func upsert(_ proposal: ArgoCoachProposal) {
+        var proposals = loadAll()
+        if let index = proposals.firstIndex(where: { $0.id == proposal.id }) {
+            proposals[index] = proposal
+        } else {
+            proposals.append(proposal)
+        }
+        saveAll(proposals)
+    }
+
+    @discardableResult
+    func updateStatus(
+        proposalId: String,
+        status: ArgoCoachProposal.Status,
+        at date: Date = Date()
+    ) -> ArgoCoachProposal? {
+        var proposals = loadAll()
+        guard let index = proposals.firstIndex(where: { $0.id == proposalId }) else {
+            return nil
+        }
+
+        let updated = proposals[index].updatingStatus(status, at: date)
+        proposals[index] = updated
+        saveAll(proposals)
+        return updated
+    }
+
+    private func loadAll() -> [ArgoCoachProposal] {
+        guard let data = defaults.data(forKey: storageKey) else {
+            return []
+        }
+
+        do {
+            return try JSONDecoder().decode([ArgoCoachProposal].self, from: data)
+        } catch {
+            print("LocalArgoCoachProposalStore: failed to decode proposals:", error)
+            return []
+        }
+    }
+
+    private func saveAll(_ proposals: [ArgoCoachProposal]) {
+        do {
+            let data = try JSONEncoder().encode(proposals)
+            defaults.set(data, forKey: storageKey)
+        } catch {
+            print("LocalArgoCoachProposalStore: failed to encode proposals:", error)
+        }
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Services/ClientDailyContextService.swift
@@ -11,6 +11,7 @@ final class ClientDailyContextService: DailyContextProviding {
     private let journalService: JournalEntriesServiceProtocol
     private let workoutReflectionsService: WorkoutReflectionsServiceProtocol
     private let dailyEntriesService: DailyEntriesServiceProtocol
+    private let proposalStore: ArgoCoachProposalStoring
     private let whoopDataProvider: @MainActor (Date) -> WhoopDailyData?
     private let healthKitWorkoutsProvider: @MainActor (Date) -> [HKWorkoutSummary]
 
@@ -19,6 +20,7 @@ final class ClientDailyContextService: DailyContextProviding {
         journalService: JournalEntriesServiceProtocol? = nil,
         workoutReflectionsService: WorkoutReflectionsServiceProtocol? = nil,
         dailyEntriesService: DailyEntriesServiceProtocol? = nil,
+        proposalStore: ArgoCoachProposalStoring? = nil,
         whoopDataProvider: (@MainActor (Date) -> WhoopDailyData?)? = nil,
         healthKitWorkoutsProvider: (@MainActor (Date) -> [HKWorkoutSummary])? = nil
     ) {
@@ -26,6 +28,7 @@ final class ClientDailyContextService: DailyContextProviding {
         self.journalService = journalService ?? JournalEntriesService()
         self.workoutReflectionsService = workoutReflectionsService ?? WorkoutReflectionsService()
         self.dailyEntriesService = dailyEntriesService ?? DailyEntriesService()
+        self.proposalStore = proposalStore ?? LocalArgoCoachProposalStore()
         self.whoopDataProvider = whoopDataProvider ?? { date in
             guard Calendar.current.isDateInToday(date) else { return nil }
             return WhoopService.shared.dailyData
@@ -96,7 +99,7 @@ final class ClientDailyContextService: DailyContextProviding {
             whoop: whoop,
             sourceFailures: sourceFailures
         )
-        let events = ArgoDailyEventMapper.makeEvents(
+        let baseEvents = ArgoDailyEventMapper.makeEvents(
             dailyEntry: dailyEntry,
             nutrition: nutrition,
             journalEntries: journalEntries,
@@ -104,6 +107,37 @@ final class ClientDailyContextService: DailyContextProviding {
             plannedWorkouts: plannedWorkouts,
             healthKitWorkouts: healthKitWorkouts,
             whoop: whoop
+        )
+        let baseContext = ArgoDailyContext(
+            date: date,
+            dailyEntry: dailyEntry,
+            events: baseEvents,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop,
+            coachProposals: [],
+            derived: derived
+        )
+        let existingProposals = proposalStore.loadProposals(for: date)
+        let coachProposals = ArgoCoachProposalGenerator.makeProposals(
+            for: baseContext,
+            existing: existingProposals
+        )
+        for proposal in coachProposals where !existingProposals.contains(where: { $0.id == proposal.id }) {
+            proposalStore.upsert(proposal)
+        }
+        let events = ArgoDailyEventMapper.makeEvents(
+            dailyEntry: dailyEntry,
+            nutrition: nutrition,
+            journalEntries: journalEntries,
+            workoutReflections: workoutReflections,
+            plannedWorkouts: plannedWorkouts,
+            healthKitWorkouts: healthKitWorkouts,
+            whoop: whoop,
+            coachProposals: coachProposals
         )
 
         return ArgoDailyContext(
@@ -116,6 +150,7 @@ final class ClientDailyContextService: DailyContextProviding {
             plannedWorkouts: plannedWorkouts,
             healthKitWorkouts: healthKitWorkouts,
             whoop: whoop,
+            coachProposals: coachProposals,
             derived: derived
         )
     }

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
@@ -9,52 +9,24 @@ import SwiftUI
 
 struct CoachView: View {
     private let contextService: DailyContextProviding
+    private let proposalStore: ArgoCoachProposalStoring
+    private let onAction: (ArgoCoachProposal) -> Void
     @State private var context: ArgoDailyContext?
     @State private var contextRefreshID = UUID()
 
     @MainActor
-    init(contextService: DailyContextProviding? = nil) {
+    init(
+        contextService: DailyContextProviding? = nil,
+        proposalStore: ArgoCoachProposalStoring? = nil,
+        onAction: @escaping (ArgoCoachProposal) -> Void = { _ in }
+    ) {
         self.contextService = contextService ?? ClientDailyContextService()
+        self.proposalStore = proposalStore ?? LocalArgoCoachProposalStore()
+        self.onAction = onAction
     }
 
-    private var recommendations: [ArgoCoachAction] {
-        var actions: [ArgoCoachAction] = []
-
-        func appendIfUnique(_ action: ArgoCoachAction) {
-            guard !actions.contains(where: { $0.id == action.id }) else { return }
-            actions.append(action)
-        }
-
-        if let nextAction = context?.derived.nextAction {
-            appendIfUnique(nextAction)
-        }
-
-        if context?.derived.missingContext.contains(.noMeals) == true,
-           !actions.contains(where: { $0.kind == .logMeal }) {
-            appendIfUnique(
-                ArgoCoachAction(
-                    id: "coach-log-meal",
-                    title: "Add food context.",
-                    body: "A quick meal photo or text note helps Argo estimate fuel for the rest of the day.",
-                    primaryLabel: "Log meal",
-                    kind: .logMeal
-                )
-            )
-        }
-
-        if context?.derived.missingContext.contains(.missingWearableData) == true {
-            appendIfUnique(
-                ArgoCoachAction(
-                    id: "coach-connect-wearable",
-                    title: "Wearable data is missing.",
-                    body: "Recovery and strain recommendations improve when Whoop, Garmin, or Apple Health data is current.",
-                    primaryLabel: "Review",
-                    kind: .recoveryHabit
-                )
-            )
-        }
-
-        return Array(actions.prefix(3))
+    private var proposals: [ArgoCoachProposal] {
+        context?.coachProposals.filter(\.isVisible) ?? []
     }
 
     var body: some View {
@@ -128,28 +100,34 @@ struct CoachView: View {
                 .font(DesignSystem.Typography.headlineMedium)
                 .foregroundColor(DesignSystem.Colors.primaryText)
 
-            ForEach(recommendations) { recommendation in
-                recommendationCard(recommendation)
+            ForEach(proposals) { proposal in
+                recommendationCard(proposal)
             }
         }
     }
 
-    private func recommendationCard(_ recommendation: ArgoCoachAction) -> some View {
+    private func recommendationCard(_ proposal: ArgoCoachProposal) -> some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-                Text(recommendation.title)
+                Text(proposal.action.title)
                     .font(DesignSystem.Typography.headlineSmall)
                     .foregroundColor(DesignSystem.Colors.primaryText)
 
-                Text(recommendation.body)
+                Text(proposal.action.body)
                     .font(DesignSystem.Typography.bodyMedium)
                     .foregroundColor(DesignSystem.Colors.secondaryText)
             }
 
             HStack(spacing: DesignSystem.Spacing.sm) {
-                actionButton(recommendation.primaryLabel, filled: true)
-                actionButton("Edit", filled: false)
-                actionButton("Skip", filled: false)
+                actionButton(proposal.action.primaryLabel, filled: true) {
+                    acceptProposal(proposal)
+                }
+                actionButton("Edit", filled: false) {
+                    editProposal(proposal)
+                }
+                actionButton("Skip", filled: false) {
+                    skipProposal(proposal)
+                }
             }
         }
         .padding(DesignSystem.Spacing.md)
@@ -161,9 +139,10 @@ struct CoachView: View {
         .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card))
     }
 
-    private func actionButton(_ title: String, filled: Bool) -> some View {
+    private func actionButton(_ title: String, filled: Bool, action: @escaping () -> Void) -> some View {
         Button {
             HapticManager.tap()
+            action()
         } label: {
             Text(title)
                 .font(DesignSystem.Typography.buttonSmall)
@@ -178,6 +157,23 @@ struct CoachView: View {
                 .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.button))
         }
         .buttonStyle(.plain)
+    }
+
+    private func acceptProposal(_ proposal: ArgoCoachProposal) {
+        proposalStore.updateStatus(proposalId: proposal.id, status: .accepted, at: Date())
+        onAction(proposal)
+        Task { await loadContext() }
+    }
+
+    private func editProposal(_ proposal: ArgoCoachProposal) {
+        proposalStore.updateStatus(proposalId: proposal.id, status: .edited, at: Date())
+        onAction(proposal)
+        Task { await loadContext() }
+    }
+
+    private func skipProposal(_ proposal: ArgoCoachProposal) {
+        proposalStore.updateStatus(proposalId: proposal.id, status: .rejected, at: Date())
+        Task { await loadContext() }
     }
 
     private func loadContext() async {

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/MainTabView.swift
@@ -51,6 +51,9 @@ struct MainTabView: View {
     @State private var showingVoiceEntry = false
     @State private var showingWorkoutReflection = false
     @State private var showingCheckIn = false
+    @State private var showingTrainingPlanForm = false
+    @State private var activeCoachProposalID: String?
+    private let proposalStore = LocalArgoCoachProposalStore()
 
     init(initialTab: Int = 0) {
         _selectedTab = State(initialValue: AppTab(rawValue: initialTab) ?? .today)
@@ -69,7 +72,7 @@ struct MainTabView: View {
                 .opacity(selectedTab == .plan ? 1 : 0)
                 .allowsHitTesting(selectedTab == .plan)
 
-            CoachView()
+            CoachView(onAction: openCoachProposal)
                 .opacity(selectedTab == .coach ? 1 : 0)
                 .allowsHitTesting(selectedTab == .coach)
 
@@ -97,19 +100,26 @@ struct MainTabView: View {
             .presentationDragIndicator(.hidden)
         }
         .sheet(isPresented: $showingMealLog) {
-            MealLogView(date: Date(), onSaved: notifyDailyContextChanged)
+            MealLogView(date: Date(), onSaved: completeActiveCoachProposal)
         }
         .sheet(isPresented: $showingVoiceEntry) {
             QuickEntryView(date: Date()) { title, content in
                 try await saveContextEntry(title: title, content: content, tags: ["voice"])
+                completeActiveCoachProposal()
             }
         }
         .sheet(isPresented: $showingWorkoutReflection) {
-            WorkoutReflectionView(linkedPlan: nil, healthKitData: nil, onSaved: notifyDailyContextChanged)
+            WorkoutReflectionView(linkedPlan: nil, healthKitData: nil, onSaved: completeActiveCoachProposal)
         }
         .sheet(isPresented: $showingCheckIn) {
             QuickEntryView(date: Date()) { title, content in
                 try await saveContextEntry(title: title, content: content, tags: ["check-in"])
+                completeActiveCoachProposal()
+            }
+        }
+        .sheet(isPresented: $showingTrainingPlanForm) {
+            TrainingPlanFormSheet(mode: .create, date: Date()) {
+                completeActiveCoachProposal()
             }
         }
     }
@@ -219,6 +229,29 @@ struct MainTabView: View {
         NotificationCenter.default.post(name: .argoDailyContextDidChange, object: nil)
     }
 
+    private func completeActiveCoachProposal() {
+        if let proposalID = activeCoachProposalID {
+            proposalStore.updateStatus(proposalId: proposalID, status: .completed, at: Date())
+            activeCoachProposalID = nil
+        }
+        notifyDailyContextChanged()
+    }
+
+    private func openCoachProposal(_ proposal: ArgoCoachProposal) {
+        activeCoachProposalID = proposal.id
+
+        switch proposal.action.kind {
+        case .logMeal:
+            showingMealLog = true
+        case .planWorkout, .adjustTraining:
+            showingTrainingPlanForm = true
+        case .reflectWorkout:
+            showingWorkoutReflection = true
+        case .checkIn, .recoveryHabit:
+            showingCheckIn = true
+        }
+    }
+
     private func saveContextEntry(title: String, content: String, tags: [String]) async throws {
         let titleParam: String? = title.isEmpty ? nil : title
         _ = try await JournalEntriesService().createEntry(
@@ -228,7 +261,6 @@ struct MainTabView: View {
             energy: nil,
             tags: tags
         )
-        notifyDailyContextChanged()
     }
 }
 

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoCoachProposalStoreTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoCoachProposalStoreTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoCoachProposalStoreTests {
+    @Test func localStorePersistsAndUpdatesProposalStatus() throws {
+        let suiteName = "argo-coach-proposal-store-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let date = Date(timeIntervalSince1970: 6_000)
+        let store = LocalArgoCoachProposalStore(defaults: defaults)
+        let proposal = makeProposal(date: date)
+
+        store.upsert(proposal)
+        let saved = store.loadProposals(for: date)
+
+        #expect(saved.count == 1)
+        #expect(saved.first?.status == .pending)
+
+        let updated = store.updateStatus(
+            proposalId: proposal.id,
+            status: .completed,
+            at: date.addingTimeInterval(60)
+        )
+
+        #expect(updated?.status == .completed)
+        #expect(store.loadProposals(for: date).first?.status == .completed)
+    }
+
+    private func makeProposal(date: Date) -> ArgoCoachProposal {
+        let action = ArgoCoachAction(
+            id: "log-meal",
+            title: "Log your first meal.",
+            body: "Add food context.",
+            primaryLabel: "Log meal",
+            kind: .logMeal
+        )
+
+        return ArgoCoachProposal(
+            id: ArgoCoachProposal.stableID(date: date, action: action),
+            dateKey: ArgoCoachProposal.dateKey(for: date),
+            action: action,
+            status: .pending,
+            payload: [:],
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+}

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoCoachProposalTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoCoachProposalTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import Your_Daily_Dose
+
+struct ArgoCoachProposalTests {
+    @Test func generatorCreatesPendingProposalForNextAction() {
+        let date = Date(timeIntervalSince1970: 5_000)
+        let context = makeContext(date: date, action: makeAction(id: "log-meal", kind: .logMeal))
+
+        let proposals = ArgoCoachProposalGenerator.makeProposals(
+            for: context,
+            existing: [],
+            now: date
+        )
+
+        #expect(proposals.count == 1)
+        #expect(proposals.first?.id == "\(ArgoCoachProposal.dateKey(for: date))-log-meal")
+        #expect(proposals.first?.status == .pending)
+    }
+
+    @Test func rejectedProposalSuppressesSameDayRegeneration() {
+        let date = Date(timeIntervalSince1970: 5_000)
+        let action = makeAction(id: "log-meal", kind: .logMeal)
+        let context = makeContext(date: date, action: action)
+        let existing = ArgoCoachProposal(
+            id: ArgoCoachProposal.stableID(date: date, action: action),
+            dateKey: ArgoCoachProposal.dateKey(for: date),
+            action: action,
+            status: .rejected,
+            payload: [:],
+            createdAt: date,
+            updatedAt: date
+        )
+
+        let proposals = ArgoCoachProposalGenerator.makeProposals(
+            for: context,
+            existing: [existing],
+            now: date
+        )
+
+        #expect(proposals.isEmpty)
+    }
+
+    @Test func coachProposalEventCarriesStatusAndAttentionState() {
+        let date = Date(timeIntervalSince1970: 5_000)
+        let action = makeAction(id: "check-in", kind: .checkIn)
+        let proposal = ArgoCoachProposal(
+            id: ArgoCoachProposal.stableID(date: date, action: action),
+            dateKey: ArgoCoachProposal.dateKey(for: date),
+            action: action,
+            status: .pending,
+            payload: [:],
+            createdAt: date,
+            updatedAt: date
+        )
+
+        let event = ArgoDailyEventMapper.makeCoachProposalEvent(proposal)
+
+        #expect(event.source == .coach)
+        #expect(event.type == .coachRecommendation)
+        #expect(event.requiresReview)
+        #expect(event.sourceRecordId == proposal.id)
+    }
+
+    private func makeAction(id: String, kind: ArgoCoachAction.Kind) -> ArgoCoachAction {
+        ArgoCoachAction(
+            id: id,
+            title: "Action",
+            body: "Take action.",
+            primaryLabel: "Start",
+            kind: kind
+        )
+    }
+
+    private func makeContext(date: Date, action: ArgoCoachAction) -> ArgoDailyContext {
+        ArgoDailyContext(
+            date: date,
+            dailyEntry: nil,
+            events: [],
+            nutrition: nil,
+            journalEntries: [],
+            workoutReflections: [],
+            plannedWorkouts: [],
+            healthKitWorkouts: [],
+            whoop: nil,
+            coachProposals: [],
+            derived: ArgoDailySignals(
+                recoveryStatus: .unknown,
+                fuelStatus: .notStarted,
+                trainingLoadStatus: .open,
+                missingContext: [],
+                nextAction: action,
+                summaryText: "Test"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add local Argo coach proposal model, generator, and UserDefaults-backed store
- generate visible proposals from daily context and map them into Today timeline coach events
- wire Coach actions to existing meal, check-in, workout reflection, and training plan flows
- track accepted, edited, skipped, and completed proposal outcomes locally

## Verification
- git diff --check
- xcodebuild build-for-testing -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination "id=00006040-000270181A92801C" CODE_SIGNING_ALLOWED=NO

## Notes
- Full test execution is still limited locally by the existing signing/simulator issue; the test bundle compiles in build-for-testing.