### PR TITLE
Add Coach chat proposal composer

### DIFF
--- a/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoCoachProposal.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Data/ArgoCoachProposal.swift
@@ -137,4 +137,92 @@ enum ArgoCoachProposalGenerator {
             )
         }
     }
+
+    static func makeProposal(from prompt: String, date: Date, now: Date = Date()) -> ArgoCoachProposal? {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let action = action(from: trimmed) else {
+            return nil
+        }
+
+        let id = "\(ArgoCoachProposal.dateKey(for: date))-chat-\(action.id)"
+        return ArgoCoachProposal(
+            id: id,
+            dateKey: ArgoCoachProposal.dateKey(for: date),
+            action: action,
+            status: .pending,
+            payload: ["source_prompt": AnyCodable(trimmed)],
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    private static func action(from prompt: String) -> ArgoCoachAction? {
+        let lowercased = prompt.lowercased()
+
+        if containsAny(lowercased, ["adjust", "easier", "lighter", "deload", "back off"]) {
+            return ArgoCoachAction(
+                id: "chat-adjust-training",
+                title: "Adjust today's training.",
+                body: "Review today's session and make the load match your current recovery and schedule.",
+                primaryLabel: "Review plan",
+                kind: .adjustTraining
+            )
+        }
+
+        if containsAny(lowercased, ["meal", "food", "eat", "calorie", "macro", "protein"]) {
+            return ArgoCoachAction(
+                id: "chat-log-meal",
+                title: "Add food context.",
+                body: "Log the meal now so Argo can update today's fuel picture.",
+                primaryLabel: "Log meal",
+                kind: .logMeal
+            )
+        }
+
+        if containsAny(lowercased, ["reflect", "reflection", "workout felt", "session felt"]) {
+            return ArgoCoachAction(
+                id: "chat-reflect-workout",
+                title: "Reflect on the workout.",
+                body: "Capture how the session felt while the details are still fresh.",
+                primaryLabel: "Add reflection",
+                kind: .reflectWorkout
+            )
+        }
+
+        if containsAny(lowercased, ["plan", "workout", "training", "session", "lift", "run"]) {
+            return ArgoCoachAction(
+                id: "chat-plan-workout",
+                title: "Plan a training session.",
+                body: "Add the session so Argo can reason about load, fuel, and recovery.",
+                primaryLabel: "Plan workout",
+                kind: .planWorkout
+            )
+        }
+
+        if containsAny(lowercased, ["check in", "check-in", "feel", "energy", "mood"]) {
+            return ArgoCoachAction(
+                id: "chat-check-in",
+                title: "Add a quick check-in.",
+                body: "Capture how you feel so Argo can frame the rest of the day.",
+                primaryLabel: "Check in",
+                kind: .checkIn
+            )
+        }
+
+        if containsAny(lowercased, ["recover", "recovery", "sleep", "mobility", "read", "family", "friend", "relax", "game"]) {
+            return ArgoCoachAction(
+                id: "chat-recovery-habit",
+                title: "Anchor recovery today.",
+                body: "Turn this into a small recovery habit so it shows up in your day.",
+                primaryLabel: "Start habit",
+                kind: .recoveryHabit
+            )
+        }
+
+        return nil
+    }
+
+    private static func containsAny(_ text: String, _ needles: [String]) -> Bool {
+        needles.contains { text.contains($0) }
+    }
 }

--- a/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
+++ b/DailyRitualSwiftiOS/Your Daily Dose/Views/CoachView.swift
@@ -13,6 +13,8 @@ struct CoachView: View {
     private let onAction: (ArgoCoachProposal) -> Void
     @State private var context: ArgoDailyContext?
     @State private var contextRefreshID = UUID()
+    @State private var chatMessages: [CoachChatMessage] = CoachChatMessage.seed
+    @State private var draftMessage = ""
 
     @MainActor
     init(
@@ -34,7 +36,7 @@ struct CoachView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
                     header
-                    conversationPreview
+                    conversationSection
                     recommendationsSection
                 }
                 .padding(DesignSystem.Spacing.cardPadding)
@@ -61,37 +63,73 @@ struct CoachView: View {
         }
     }
 
-    private var conversationPreview: some View {
+    private var conversationSection: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            coachBubble("You are on track for the week. The main constraint is sleep debt, not motivation.")
-
-            HStack {
-                Spacer()
-                Text("Can you make tomorrow easier?")
-                    .font(DesignSystem.Typography.bodyMedium)
-                    .foregroundColor(DesignSystem.Colors.background)
-                    .padding(.horizontal, DesignSystem.Spacing.md)
-                    .padding(.vertical, DesignSystem.Spacing.sm)
-                    .background(DesignSystem.Colors.primaryText)
-                    .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card))
+            ForEach(chatMessages) { message in
+                chatBubble(message)
             }
 
-            coachBubble("Yes. Move intervals to Thursday, keep tomorrow as Zone 2, and prep a higher-carb lunch.")
+            chatComposer
         }
     }
 
-    private func coachBubble(_ text: String) -> some View {
-        Text(text)
-            .font(DesignSystem.Typography.bodyMedium)
-            .foregroundColor(DesignSystem.Colors.primaryText)
-            .padding(DesignSystem.Spacing.md)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(DesignSystem.Colors.cardBackground)
-            .overlay(
-                RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card)
-                    .stroke(DesignSystem.Colors.border, lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card))
+    private func chatBubble(_ message: CoachChatMessage) -> some View {
+        HStack {
+            if message.role == .user {
+                Spacer(minLength: 48)
+            }
+
+            Text(message.text)
+                .font(DesignSystem.Typography.bodyMedium)
+                .foregroundColor(message.role == .user ? DesignSystem.Colors.background : DesignSystem.Colors.primaryText)
+                .padding(DesignSystem.Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(message.role == .user ? DesignSystem.Colors.primaryText : DesignSystem.Colors.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card)
+                        .stroke(DesignSystem.Colors.border, lineWidth: message.role == .user ? 0 : 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.card))
+
+            if message.role == .assistant {
+                Spacer(minLength: 48)
+            }
+        }
+    }
+
+    private var chatComposer: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            TextField("Ask Argo to plan, log, reflect, or recover", text: $draftMessage, axis: .vertical)
+                .font(DesignSystem.Typography.bodyMedium)
+                .foregroundColor(DesignSystem.Colors.primaryText)
+                .lineLimit(1...3)
+                .padding(.horizontal, DesignSystem.Spacing.md)
+                .padding(.vertical, DesignSystem.Spacing.sm)
+                .background(DesignSystem.Colors.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.button)
+                        .stroke(DesignSystem.Colors.border, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.button))
+                .submitLabel(.send)
+                .onSubmit(sendMessage)
+
+            Button {
+                sendMessage()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundColor(canSendMessage ? DesignSystem.Colors.primaryText : DesignSystem.Colors.tertiaryText)
+                    .frame(width: 36, height: 36)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSendMessage)
+            .accessibilityLabel("Send message")
+        }
+    }
+
+    private var canSendMessage: Bool {
+        !draftMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var recommendationsSection: some View {
@@ -176,6 +214,29 @@ struct CoachView: View {
         Task { await loadContext() }
     }
 
+    private func sendMessage() {
+        let text = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        draftMessage = ""
+        chatMessages.append(CoachChatMessage(role: .user, text: text))
+
+        let date = context?.date ?? Date()
+        if let proposal = ArgoCoachProposalGenerator.makeProposal(from: text, date: date) {
+            proposalStore.upsert(proposal)
+            chatMessages.append(CoachChatMessage(
+                role: .assistant,
+                text: "I added that as a proposed action. Review it below before Argo changes anything."
+            ))
+            Task { await loadContext() }
+        } else {
+            chatMessages.append(CoachChatMessage(
+                role: .assistant,
+                text: "I can turn clear requests about training, meals, reflections, check-ins, or recovery into proposed actions."
+            ))
+        }
+    }
+
     private func loadContext() async {
         let refreshID = UUID()
         contextRefreshID = refreshID
@@ -183,6 +244,23 @@ struct CoachView: View {
         guard contextRefreshID == refreshID else { return }
         context = nextContext
     }
+}
+
+private struct CoachChatMessage: Identifiable {
+    let id = UUID()
+    let role: Role
+    let text: String
+
+    enum Role {
+        case user
+        case assistant
+    }
+
+    static let seed = [
+        CoachChatMessage(role: .assistant, text: "Tell me what changed today. I can turn training, food, recovery, and reflection requests into proposed actions."),
+        CoachChatMessage(role: .user, text: "Can you make tomorrow easier?"),
+        CoachChatMessage(role: .assistant, text: "Yes. Ask me to adjust training, log food, reflect on a workout, or anchor recovery.")
+    ]
 }
 
 #Preview {

--- a/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoCoachProposalTests.swift
+++ b/DailyRitualSwiftiOS/Your Daily DoseTests/ArgoCoachProposalTests.swift
@@ -62,6 +62,41 @@ struct ArgoCoachProposalTests {
         #expect(event.sourceRecordId == proposal.id)
     }
 
+    @Test func chatPromptCreatesMealProposal() {
+        let date = Date(timeIntervalSince1970: 5_100)
+
+        let proposal = ArgoCoachProposalGenerator.makeProposal(
+            from: "I ate chicken and rice for lunch",
+            date: date,
+            now: date
+        )
+
+        #expect(proposal?.action.kind == .logMeal)
+        #expect(proposal?.status == .pending)
+        #expect(proposal?.id == "\(ArgoCoachProposal.dateKey(for: date))-chat-chat-log-meal")
+    }
+
+    @Test func chatPromptPrioritizesAdjustTrainingBeforeGenericWorkoutPlan() {
+        let date = Date(timeIntervalSince1970: 5_200)
+
+        let proposal = ArgoCoachProposalGenerator.makeProposal(
+            from: "Can you make my workout lighter today?",
+            date: date,
+            now: date
+        )
+
+        #expect(proposal?.action.kind == .adjustTraining)
+    }
+
+    @Test func unsupportedChatPromptDoesNotCreateProposal() {
+        let proposal = ArgoCoachProposalGenerator.makeProposal(
+            from: "What do you think?",
+            date: Date(timeIntervalSince1970: 5_300)
+        )
+
+        #expect(proposal == nil)
+    }
+
     private func makeAction(id: String, kind: ArgoCoachAction.Kind) -> ArgoCoachAction {
         ArgoCoachAction(
             id: id,


### PR DESCRIPTION
## Summary
- replace the static Coach conversation preview with a lightweight local chat composer
- parse clear chat requests into local Argo coach proposals for meals, training, reflections, check-ins, recovery habits, and training adjustments
- keep unsupported prompts bounded with a clear assistant response instead of pretending to have full AI chat
- add focused tests for chat proposal intent generation

## Verification
- git diff --check
- xcodebuild build-for-testing -project "DailyRitualSwiftiOS/Your Daily Dose.xcodeproj" -scheme "Your Daily Dose" -destination "id=00006040-000270181A92801C" CODE_SIGNING_ALLOWED=NO

## Notes
- This is intentionally local/deterministic. It establishes the chat-to-proposal interaction model before adding backend LLM generation.